### PR TITLE
Create artist song bracket generator

### DIFF
--- a/app/(ui)/artist-bracket/page.tsx
+++ b/app/(ui)/artist-bracket/page.tsx
@@ -202,9 +202,9 @@ export default function ArtistBracketPage() {
 // moved to lib/bracket
 
 async function drawShareImage(opts: { artistName: string; finalFour: TrackSeed[]; champion: TrackSeed }): Promise<HTMLCanvasElement> {
-    // Portrait aspect ratio for mobile sharing (1080x1920)
+    // Shorter portrait aspect ratio for mobile sharing (1080x1600)
     const width = 1080;
-    const height = 1920;
+    const height = 1600;
     const canvas = document.createElement('canvas');
     canvas.width = width;
     canvas.height = height;
@@ -266,18 +266,18 @@ async function drawShareImage(opts: { artistName: string; finalFour: TrackSeed[]
     titleGradient.addColorStop(0.5, '#22d3ee'); // cyan-400
     titleGradient.addColorStop(1, '#34d399'); // green-400
 
-    ctx.font = 'bold 64px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
+    ctx.font = 'bold 72px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
     ctx.fillStyle = titleGradient;
-    ctx.fillText('Musician March Madness', 60, 100);
+    ctx.fillText('Musician March Madness', 60, 90);
 
     // Artist label with better contrast
-    ctx.font = 'bold 40px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
+    ctx.font = 'bold 48px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
     ctx.fillStyle = '#e2e8f0'; // slate-200
-    ctx.fillText(`Artist: ${opts.artistName}`, 60, 170);
+    ctx.fillText(`Artist: ${opts.artistName}`, 60, 150);
 
-    // Champion section with better layout
+    // Champion section with better layout - more space from header
     const champY = 220;
-    const champH = 280;
+    const champH = 320;
 
     // Champion background with rounded corners effect
     const champGrad = ctx.createLinearGradient(60, champY, width - 60, champY + champH);
@@ -296,86 +296,110 @@ async function drawShareImage(opts: { artistName: string; finalFour: TrackSeed[]
     ctx.stroke();
 
     // Crown emoji and title
-    ctx.font = 'bold 54px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
+    ctx.font = 'bold 60px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
     ctx.fillStyle = '#fbbf24'; // amber-400
     ctx.fillText('👑 CHAMPION', 100, champY + 80);
 
-    // Champion album art (if available)
+    // Champion album art (if available) - bigger
     const championImage = images[0];
     if (championImage) {
         ctx.save();
         // Create circular clip for champion album art
         ctx.beginPath();
-        ctx.arc(180, champY + 160, 50, 0, Math.PI * 2);
+        ctx.arc(200, champY + 180, 70, 0, Math.PI * 2);
         ctx.clip();
-        ctx.drawImage(championImage, 130, champY + 110, 100, 100);
+        ctx.drawImage(championImage, 130, champY + 110, 140, 140);
         ctx.restore();
     }
 
     // Champion name with better typography - adjusted for image
-    ctx.font = 'bold 48px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
+    ctx.font = 'bold 52px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
     ctx.fillStyle = '#ffffff';
-    const champTextX = championImage ? 300 : 100;
-    const champTextW = championImage ? width - 360 : width - 200;
-    wrapText(ctx, opts.champion.name, champTextX, champY + 150, champTextW, 56);
+    const champTextX = championImage ? 320 : 100;
+    const champTextW = championImage ? width - 380 : width - 200;
+    wrapText(ctx, opts.champion.name, champTextX, champY + 170, champTextW, 60);
 
     // Seed number
-    ctx.font = 'bold 32px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
+    ctx.font = 'bold 36px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
     ctx.fillStyle = '#fbbf24';
-    ctx.fillText(`Seed #${opts.champion.seed}`, champTextX, champY + 230);
+    ctx.fillText(`Seed #${opts.champion.seed}`, champTextX, champY + 250);
 
-    // Final Four section with improved spacing - moved down more
-    const ffY = champY + champH + 100;
+    // Final Four section with much more space from champion section
+    const ffY = champY + champH + 120;
     const ffCardW = width - 120;
-    const ffCardH = 200;
+    const ffCardH = 180;
 
-    ctx.font = 'bold 40px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
+    ctx.font = 'bold 48px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
     ctx.fillStyle = '#e2e8f0';
-    ctx.fillText('Final Four', 60, ffY - 20);
+    ctx.fillText('Final Four', 60, ffY - 15);
 
-    for (let i = 0; i < Math.min(4, opts.finalFour.length); i++) {
+    // Sort Final Four by podium order: champion first, then others
+    const sortedFinalFour = [...opts.finalFour];
+    const championIndex = sortedFinalFour.findIndex(track => track.id === opts.champion.id);
+    if (championIndex > -1) {
+        // Move champion to first position
+        const champion = sortedFinalFour.splice(championIndex, 1)[0];
+        sortedFinalFour.unshift(champion);
+    }
+
+    // Podium colors (subtle)
+    const podiumColors = [
+        { bg: 'rgba(255, 215, 0, 0.15)', border: 'rgba(255, 215, 0, 0.4)', name: '🥇' }, // Gold
+        { bg: 'rgba(192, 192, 192, 0.15)', border: 'rgba(192, 192, 192, 0.4)', name: '🥈' }, // Silver  
+        { bg: 'rgba(205, 127, 50, 0.15)', border: 'rgba(205, 127, 50, 0.4)', name: '🥉' }, // Bronze
+        { bg: 'rgba(205, 127, 50, 0.15)', border: 'rgba(205, 127, 50, 0.4)', name: '🥉' }  // Bronze
+    ];
+
+    for (let i = 0; i < Math.min(4, sortedFinalFour.length); i++) {
         const x = 60;
-        const y = ffY + i * (ffCardH + 30);
+        const y = ffY + i * (ffCardH + 25); // Slightly more spacing between cards
 
-        // Card with rounded corners
-        ctx.fillStyle = 'rgba(51, 65, 85, 0.8)'; // slate-700/80
+        const track = sortedFinalFour[i];
+        const podium = podiumColors[i];
+
+        // Card with podium-colored background
+        ctx.fillStyle = podium.bg;
         roundRect(ctx, x, y, ffCardW, ffCardH, 20);
         ctx.fill();
 
-        ctx.strokeStyle = 'rgba(148, 163, 184, 0.6)';
+        // Card border with podium color
+        ctx.strokeStyle = podium.border;
         ctx.lineWidth = 3;
         roundRect(ctx, x, y, ffCardW, ffCardH, 20);
         ctx.stroke();
 
-        // Album art from loaded images
-        const track = opts.finalFour[i];
-        const trackImage = images[i + 1]; // +1 because index 0 is champion image
+        // Find the correct image for this track
+        const originalIndex = opts.finalFour.findIndex(t => t.id === track.id);
+        const trackImage = images[originalIndex + 1]; // +1 because index 0 is champion image
+
+        // Podium medal in top-right corner
+        ctx.font = '32px system-ui';
+        ctx.fillText(podium.name, x + ffCardW - 60, y + 40);
 
         if (trackImage) {
             ctx.save();
             // Create circular clip for album art
             ctx.beginPath();
-            ctx.arc(x + 60, y + 100, 40, 0, Math.PI * 2);
+            ctx.arc(x + 70, y + 90, 50, 0, Math.PI * 2);
             ctx.clip();
-            ctx.drawImage(trackImage, x + 20, y + 60, 80, 80);
+            ctx.drawImage(trackImage, x + 20, y + 40, 100, 100);
             ctx.restore();
         }
 
-        // Song info - adjusted to make room for album art
+        // Song info - adjusted to make room for bigger album art
         ctx.fillStyle = '#ffffff';
-        ctx.font = 'bold 32px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
-        const textX = trackImage ? x + 120 : x + 40; // Move text right if there's album art
-        const textW = trackImage ? ffCardW - 160 : ffCardW - 80;
-        wrapText(ctx, `#${track.seed} ${track.name}`, textX, y + 80, textW, 40);
+        ctx.font = 'bold 38px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
+        const textX = trackImage ? x + 140 : x + 40; // Move text right if there's album art
+        const textW = trackImage ? ffCardW - 200 : ffCardW - 100; // Extra space for medal
+        wrapText(ctx, `#${track.seed} ${track.name}`, textX, y + 90, textW, 46);
     }
 
-    // Footer with better styling
-    ctx.font = '24px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
+    // Footer with better styling 
+    ctx.font = '28px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
     ctx.fillStyle = '#94a3b8';
-    const date = new Date().toLocaleDateString();
-    const footerText = `Created ${date} • djziff.com`;
+    const footerText = `Built on djziff.com`;
     const footerWidth = ctx.measureText(footerText).width;
-    ctx.fillText(footerText, (width - footerWidth) / 2, height - 60);
+    ctx.fillText(footerText, (width - footerWidth) / 2, height - 40);
 
     return canvas;
 

--- a/app/(ui)/artist-bracket/page.tsx
+++ b/app/(ui)/artist-bracket/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
+import ArtistSearch from '@/components/search/ArtistSearch';
 import { Button } from '@/components/ui/button';
-// Removed login component for bracket flow
+import Bracket from '@/components/bracket/Bracket';
+import { pickFinalFour, getChampion } from '@/lib/bracket';
 
 type Artist = {
     id: string;
@@ -14,197 +15,21 @@ type Artist = {
     followers: number;
 };
 
-type TrackSeed = {
-    id: string;
-    name: string;
-    image: string | null;
-    popularity: number;
-    preview_url: string | null;
-    uri: string;
-    seed: number;
-};
-
-type Matchup = {
-    id: string;
-    a: TrackSeed | null;
-    b: TrackSeed | null;
-    winnerId?: string;
-};
-
-function buildInitialRound(seeds: TrackSeed[]): Matchup[] {
-    const n = seeds.length;
-    const matchups: Matchup[] = [];
-    for (let i = 0; i < Math.floor(n / 2); i++) {
-        const top = seeds[i];
-        const bottom = seeds[n - 1 - i];
-        matchups.push({ id: `r${n}-${i}`, a: top, b: bottom });
-    }
-    return matchups;
-}
-
-function advanceRound(prevRound: Matchup[]): Matchup[] {
-    const winners: (TrackSeed | null)[] = [];
-    for (const m of prevRound) {
-        const winner = m.winnerId === m.a?.id ? m.a : m.winnerId === m.b?.id ? m.b : null;
-        winners.push(winner);
-    }
-    const next: Matchup[] = [];
-    for (let i = 0; i < winners.length; i += 2) {
-        next.push({ id: `${prevRound[0]?.id}-n${i / 2}`, a: winners[i] || null, b: winners[i + 1] || null });
-    }
-    return next;
-}
-
-function Bracket({ seeds, onChampion, onRoundsChange }: { seeds: TrackSeed[]; onChampion: (t: TrackSeed) => void; onRoundsChange?: (rounds: Matchup[][]) => void }) {
-    const [rounds, setRounds] = useState<Matchup[][]>(() => [buildInitialRound(seeds)]);
-
-    const totalRounds = Math.max(1, Math.log2(Math.max(1, seeds.length)));
-
-    function getRoundNames(size: number): string[] {
-        const names: string[] = [];
-        const labels: Record<number, string> = {
-            64: 'Round of 64',
-            32: 'Round of 32',
-            16: 'Sweet 16',
-            8: 'Elite 8',
-            4: 'Final 4',
-            2: 'Championship',
-        };
-        let n = size;
-        while (n >= 2) {
-            names.push(labels[n] || `Round of ${n}`);
-            n = n / 2;
-        }
-        return names;
-    }
-
-    const roundNames = getRoundNames(seeds.length);
-
-    useEffect(() => {
-        const initial = [buildInitialRound(seeds)];
-        setRounds(initial);
-    }, [seeds]);
-
-    // Notify parent when rounds change (avoid calling during render/update functions)
-    useEffect(() => {
-        onRoundsChange?.(rounds);
-    }, [rounds, onRoundsChange]);
-
-    // Notify parent when a champion is decided
-    useEffect(() => {
-        const lastRound = rounds[rounds.length - 1];
-        if (!lastRound || lastRound.length === 0) return;
-        const finalMatch = lastRound[0];
-        if (!finalMatch?.winnerId) return;
-        const champ = finalMatch.winnerId === finalMatch.a?.id ? finalMatch.a : finalMatch.b;
-        if (champ) onChampion(champ);
-    }, [rounds, onChampion]);
-
-    const selectWinner = (roundIndex: number, matchupIndex: number, winnerId: string) => {
-        setRounds((prev) => {
-            const copy = prev.map((r) => r.map((m) => ({ ...m })));
-            copy[roundIndex][matchupIndex].winnerId = winnerId;
-
-            // If round complete, create next round or update next round pairing
-            const currentRound = copy[roundIndex];
-            const isComplete = currentRound.every((m) => !!m.winnerId);
-            const isLastRound = roundIndex === totalRounds - 1;
-            if (!isLastRound) {
-                if (!copy[roundIndex + 1]) {
-                    copy[roundIndex + 1] = advanceRound(currentRound);
-                } else {
-                    // Update winners into already created next round
-                    const next = copy[roundIndex + 1];
-                    const pairIndex = Math.floor(matchupIndex / 2);
-                    const isFirst = matchupIndex % 2 === 0;
-                    const winner = currentRound[matchupIndex].winnerId === currentRound[matchupIndex].a?.id
-                        ? currentRound[matchupIndex].a
-                        : currentRound[matchupIndex].b;
-                    if (isFirst) next[pairIndex].a = winner || null; else next[pairIndex].b = winner || null;
-                }
-            }
-
-            return copy;
-        });
-    };
-
-    return (
-        <div className="overflow-x-auto">
-            <div className="grid gap-4 min-w-[1200px]" style={{ gridTemplateColumns: `repeat(${roundNames.length + 1}, minmax(0, 1fr))` }}>
-                {roundNames.map((title, colIdx) => (
-                    <div key={title} className="space-y-2">
-                        <div className="text-center font-semibold text-sm mb-2">{title}</div>
-                        {(rounds[colIdx] || []).map((m, i) => (
-                            <Card key={m.id} className="p-2">
-                                <div className="flex flex-col gap-2">
-                                    <button
-                                        className={`text-left p-2 rounded border ${m.winnerId === m.a?.id ? 'bg-green-100 dark:bg-green-900/30 border-green-400' : 'hover:bg-gray-50 dark:hover:bg-slate-800'}`}
-                                        onClick={() => m.a && selectWinner(colIdx, i, m.a.id)}
-                                        disabled={!m.a}
-                                    >
-                                        <div className="flex items-center gap-2">
-                                            {m.a?.image && <img src={m.a.image} alt="" className="h-6 w-6 rounded-sm object-cover" />}
-                                            <div className="text-xs">{m.a ? `(${m.a.seed}) ${m.a.name}` : 'TBD'}</div>
-                                        </div>
-                                    </button>
-                                    <button
-                                        className={`text-left p-2 rounded border ${m.winnerId === m.b?.id ? 'bg-green-100 dark:bg-green-900/30 border-green-400' : 'hover:bg-gray-50 dark:hover:bg-slate-800'}`}
-                                        onClick={() => m.b && selectWinner(colIdx, i, m.b.id)}
-                                        disabled={!m.b}
-                                    >
-                                        <div className="flex items-center gap-2">
-                                            {m.b?.image && <img src={m.b.image} alt="" className="h-6 w-6 rounded-sm object-cover" />}
-                                            <div className="text-xs">{m.b ? `(${m.b.seed}) ${m.b.name}` : 'TBD'}</div>
-                                        </div>
-                                    </button>
-                                </div>
-                            </Card>
-                        ))}
-                    </div>
-                ))}
-                <div className="space-y-2">
-                    <div className="text-center font-semibold text-sm mb-2">Winner</div>
-                    <Card className="p-4 text-center">
-                        <div className="text-sm text-gray-600 dark:text-gray-300">Pick winners to decide the champion</div>
-                    </Card>
-                </div>
-            </div>
-        </div>
-    );
-}
+import type { TrackSeed, Matchup } from '@/lib/bracket';
 
 export default function ArtistBracketPage() {
     const [error, setError] = useState<string | null>(null);
     const [query, setQuery] = useState('');
     const [isSearching, setIsSearching] = useState(false);
-    const [results, setResults] = useState<Artist[]>([]);
     const [selected, setSelected] = useState<Artist | null>(null);
     const [seeds, setSeeds] = useState<TrackSeed[]>([]);
     const [champion, setChampion] = useState<TrackSeed | null>(null);
     const [roundsSnapshot, setRoundsSnapshot] = useState<Matchup[][]>([]);
     const [imageUrl, setImageUrl] = useState<string | null>(null);
-    const [bracketSize, setBracketSize] = useState<number>(64);
+    const [bracketSize, setBracketSize] = useState<number>(8);
+    const [isGenerating, setIsGenerating] = useState<boolean>(false);
 
-    useEffect(() => {
-        if (!query.trim()) {
-            setResults([]);
-            return;
-        }
-        const t = setTimeout(async () => {
-            setIsSearching(true);
-            try {
-                const res = await fetch(`/api/spotify-search-artist?q=${encodeURIComponent(query)}`);
-                const data = await res.json();
-                if (res.ok) setResults(data.artists || []);
-                else setResults([]);
-            } catch (_) {
-                setResults([]);
-            } finally {
-                setIsSearching(false);
-            }
-        }, 300);
-        return () => clearTimeout(t);
-    }, [query]);
+    // search handled by ArtistSearch
 
     const generateBracket = async () => {
         if (!selected) return;
@@ -212,6 +37,7 @@ export default function ArtistBracketPage() {
         setSeeds([]);
         setChampion(null);
         try {
+            setIsGenerating(true);
             const res = await fetch(`/api/spotify-artist-tracks?artistId=${selected.id}&size=${bracketSize}`);
             const data = await res.json();
             if (!res.ok) throw new Error(data?.error || 'Failed to fetch tracks');
@@ -220,53 +46,40 @@ export default function ArtistBracketPage() {
                 return;
             }
             setSeeds(data.tracks as TrackSeed[]);
-        } catch (e: any) {
-            setError(e.message || 'Error generating bracket');
+        } catch (e: unknown) {
+            setError((e as Error).message || 'Error generating bracket');
+        } finally {
+            setIsGenerating(false);
         }
     };
 
     return (
         <div className="container mx-auto px-4 py-8 space-y-8">
-            <Card className="max-w-4xl mx-auto">
+            <Card className="max-w-5xl mx-auto bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white border-0 shadow-xl">
                 <CardHeader>
-                    <CardTitle>Artist Song Bracket</CardTitle>
+                    <CardTitle>
+                        <span className="bg-gradient-to-r from-fuchsia-400 via-cyan-400 to-emerald-400 bg-clip-text text-transparent text-2xl md:text-3xl font-extrabold tracking-tight">
+                            Artist Song Bracket
+                        </span>
+                    </CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-4">
                     <div className="space-y-4">
-                        <div className="relative">
-                            <Input
-                                placeholder="Search for an artist"
-                                value={query}
-                                onChange={(e) => setQuery(e.target.value)}
-                            />
-                            {results.length > 0 && (
-                                <div className="absolute z-10 mt-1 w-full bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-md shadow-md max-h-64 overflow-y-auto">
-                                    {results.map((a) => (
-                                        <button
-                                            key={a.id}
-                                            className="w-full text-left p-2 hover:bg-gray-50 dark:hover:bg-slate-800 flex items-center gap-2"
-                                            onClick={() => {
-                                                setSelected(a);
-                                                setQuery(a.name);
-                                                setResults([]);
-                                            }}
-                                        >
-                                            {a.images?.[a.images.length - 1]?.url && (
-                                                <img src={a.images[a.images.length - 1].url} alt={a.name} className="h-6 w-6 rounded-sm object-cover" />
-                                            )}
-                                            <span className="text-sm">{a.name}</span>
-                                        </button>
-                                    ))}
-                                </div>
-                            )}
-                        </div>
+                        <ArtistSearch
+                            value={query}
+                            onChange={setQuery}
+                            onSelect={(a) => {
+                                setSelected(a as any);
+                                setQuery(a.name);
+                            }}
+                        />
 
-                        <div className="flex items-center gap-2">
+                        <div className="flex flex-col sm:flex-row sm:items-center gap-2">
                             <div className="flex items-center gap-2">
                                 <label htmlFor="bracket-size" className="text-sm text-gray-600 dark:text-gray-400">Bracket size:</label>
                                 <select
                                     id="bracket-size"
-                                    className="border rounded px-2 py-1 bg-white dark:bg-slate-900 text-sm"
+                                    className="border rounded px-2 py-1 bg-white/90 dark:bg-slate-900/60 text-sm"
                                     value={bracketSize}
                                     onChange={(e) => setBracketSize(Number(e.target.value))}
                                 >
@@ -275,8 +88,18 @@ export default function ArtistBracketPage() {
                                     ))}
                                 </select>
                             </div>
-                            <Button onClick={generateBracket} disabled={!selected || isSearching}>
-                                {isSearching ? 'Loading…' : `Generate ${bracketSize}-Song Bracket`}
+                            <Button onClick={generateBracket} disabled={!selected || isSearching || isGenerating} className="relative">
+                                {(isGenerating) ? (
+                                    <span className="inline-flex items-center">
+                                        <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+                                        </svg>
+                                        Generating…
+                                    </span>
+                                ) : (
+                                    (isSearching ? 'Loading…' : `Generate ${bracketSize}-Song Bracket`)
+                                )}
                             </Button>
                             {selected && (
                                 <div className="text-sm text-gray-600 dark:text-gray-400">Selected: <span className="font-medium">{selected.name}</span></div>
@@ -287,8 +110,10 @@ export default function ArtistBracketPage() {
                             <div className="space-y-4">
                                 <Bracket seeds={seeds} onChampion={setChampion} onRoundsChange={setRoundsSnapshot} />
                                 {champion && (
-                                    <Card className="p-4">
-                                        <div className="text-center">Champion: <span className="font-semibold">{champion.name}</span></div>
+                                    <Card className="p-4 bg-white/80 dark:bg-slate-900/60 backdrop-blur">
+                                        <div className="text-center text-lg">
+                                            <span className="text-gray-600 dark:text-gray-300">Champion:</span> <span className="font-semibold">{champion.name}</span>
+                                        </div>
                                         <div className="flex justify-center mt-4">
                                             <Button onClick={() => generateShareImage()}>Download PNG</Button>
                                         </div>
@@ -333,22 +158,7 @@ export default function ArtistBracketPage() {
     }
 }
 
-function pickFinalFour(rounds: Matchup[][]): TrackSeed[] {
-    if (!rounds || rounds.length < 2) return [];
-    const semifinalRound = rounds[rounds.length - 2] || [];
-    const participants: TrackSeed[] = [];
-    for (const m of semifinalRound) {
-        if (m.a) participants.push(m.a);
-        if (m.b) participants.push(m.b);
-    }
-    return participants.slice(0, 4);
-}
-
-function getChampion(rounds: Matchup[][]): TrackSeed | null {
-    const last = rounds[rounds.length - 1]?.[0];
-    if (!last) return null;
-    return last.winnerId === last.a?.id ? last.a || null : last.b || null;
-}
+// moved to lib/bracket
 
 function drawShareImage(opts: { artistName: string; finalFour: TrackSeed[]; champion: TrackSeed }): HTMLCanvasElement {
     const width = 1200;
@@ -358,37 +168,61 @@ function drawShareImage(opts: { artistName: string; finalFour: TrackSeed[]; cham
     canvas.height = height;
     const ctx = canvas.getContext('2d')!;
 
-    // Background
-    ctx.fillStyle = '#0f172a'; // slate-900
+    // Gradient background
+    const gradient = ctx.createLinearGradient(0, 0, width, height);
+    gradient.addColorStop(0, '#0f172a'); // slate-900
+    gradient.addColorStop(0.5, '#1e293b'); // slate-800
+    gradient.addColorStop(1, '#0f172a');
+    ctx.fillStyle = gradient;
     ctx.fillRect(0, 0, width, height);
 
+    // Accent gradient for title text
+    const titleGradient = ctx.createLinearGradient(40, 40, 700, 100);
+    titleGradient.addColorStop(0, '#f472b6'); // pink-400
+    titleGradient.addColorStop(0.5, '#22d3ee'); // cyan-400
+    titleGradient.addColorStop(1, '#34d399'); // green-400
+
     // Title
-    ctx.fillStyle = '#ffffff';
-    ctx.font = 'bold 42px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif';
-    ctx.fillText('DJ Tools - Artist Song Bracket', 40, 70);
+    ctx.font = '800 46px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif';
+    ctx.fillStyle = titleGradient;
+    ctx.fillText('Artist Song Bracket', 40, 70);
 
-    // Artist
-    ctx.font = 'bold 36px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif';
+    // Artist label
+    ctx.font = '700 34px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif';
     ctx.fillStyle = '#93c5fd';
-    ctx.fillText(`Artist: ${opts.artistName}`, 40, 120);
+    wrapText(ctx, `Artist: ${opts.artistName}`, 40, 120, width - 80, 38);
 
-    // Champion box
-    ctx.fillStyle = '#22c55e';
-    ctx.fillRect(40, 160, width - 80, 160);
-    ctx.fillStyle = '#0f172a';
-    ctx.font = 'bold 40px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif';
-    ctx.fillText('Champion', 60, 210);
-    ctx.font = 'bold 34px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif';
-    wrapText(ctx, opts.champion.name, 60, 250, width - 120, 38);
+    // Champion card
+    const cardX = 40;
+    const cardY = 160;
+    const cardW = width - 80;
+    const cardH = 170;
+    // Card background with soft gradient
+    const cardGrad = ctx.createLinearGradient(cardX, cardY, cardX + cardW, cardY + cardH);
+    cardGrad.addColorStop(0, 'rgba(59, 130, 246, 0.25)'); // blue-500/25
+    cardGrad.addColorStop(1, 'rgba(16, 185, 129, 0.25)'); // emerald-500/25
+    ctx.fillStyle = cardGrad;
+    ctx.fillRect(cardX, cardY, cardW, cardH);
+    // Border
+    ctx.strokeStyle = 'rgba(148, 163, 184, 0.4)';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(cardX, cardY, cardW, cardH);
 
-    // Final Four grid
-    const ffX = 40;
-    const ffY = 360;
-    const ffW = (width - 80 - 30) / 2;
-    const ffH = 110;
-
-    ctx.font = 'bold 28px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif';
+    ctx.fillStyle = '#e5e7eb';
+    ctx.font = '800 38px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif';
+    ctx.fillText('Champion', cardX + 20, cardY + 52);
     ctx.fillStyle = '#ffffff';
+    ctx.font = '700 32px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif';
+    wrapText(ctx, opts.champion.name, cardX + 20, cardY + 98, cardW - 40, 36);
+
+    // Final Four section
+    const ffX = 40;
+    const ffY = 370;
+    const ffW = (width - 80 - 30) / 2;
+    const ffH = 112;
+
+    ctx.font = '800 28px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif';
+    ctx.fillStyle = '#e5e7eb';
     ctx.fillText('Final Four', ffX, ffY - 16);
 
     for (let i = 0; i < Math.min(4, opts.finalFour.length); i++) {
@@ -397,18 +231,23 @@ function drawShareImage(opts: { artistName: string; finalFour: TrackSeed[]; cham
         const x = ffX + col * (ffW + 30);
         const y = ffY + row * (ffH + 20);
 
-        // Card
-        ctx.fillStyle = '#1f2937'; // gray-800
+        // Card background
+        ctx.fillStyle = 'rgba(15, 23, 42, 0.8)'; // slate-900/80
         ctx.fillRect(x, y, ffW, ffH);
+        // Border
+        ctx.strokeStyle = 'rgba(100, 116, 139, 0.6)';
+        ctx.lineWidth = 1.5;
+        ctx.strokeRect(x, y, ffW, ffH);
         ctx.fillStyle = '#ffffff';
-        ctx.font = 'bold 22px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif';
+        ctx.font = '700 20px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif';
         wrapText(ctx, `(${opts.finalFour[i].seed}) ${opts.finalFour[i].name}`, x + 16, y + 36, ffW - 32, 26);
     }
 
     // Footer
     ctx.fillStyle = '#94a3b8';
     ctx.font = '20px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif';
-    ctx.fillText('Create your own at djziff.com', 40, height - 30);
+    const date = new Date().toLocaleDateString();
+    ctx.fillText(`Created on ${date} · djziff.com`, 40, height - 30);
 
     return canvas;
 }

--- a/app/(ui)/artist-bracket/page.tsx
+++ b/app/(ui)/artist-bracket/page.tsx
@@ -60,13 +60,26 @@ export default function ArtistBracketPage() {
 
     return (
         <div className="container mx-auto px-4 py-8 space-y-8">
-            <Card className="max-w-5xl mx-auto bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white border-0 shadow-xl">
-                <CardHeader>
-                    <CardTitle>
-                        <span className="bg-gradient-to-r from-fuchsia-400 via-cyan-400 to-emerald-400 bg-clip-text text-transparent text-2xl md:text-3xl font-extrabold tracking-tight">
-                            Musician March Madness
-                        </span>
-                    </CardTitle>
+            <Card className="max-w-5xl mx-auto bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white border-0 shadow-2xl">
+                <div className="absolute inset-0 bg-gradient-to-br from-purple-500/10 via-transparent to-blue-500/10 pointer-events-none"></div>
+                <CardHeader className="relative z-10 bg-gradient-to-r from-slate-800/50 to-slate-900/50 backdrop-blur border-b border-slate-700/50 overflow-visible">
+                    <div className="text-center space-y-4">
+                        <div className="flex items-center justify-center gap-3">
+                            <div className="text-4xl animate-pulse">🎵</div>
+                            <CardTitle>
+                                <span className="bg-gradient-to-r from-fuchsia-400 via-cyan-400 to-emerald-400 bg-clip-text text-transparent text-3xl md:text-4xl font-extrabold tracking-tight drop-shadow-lg">
+                                    Musician March Madness
+                                </span>
+                            </CardTitle>
+                            <div className="text-4xl animate-pulse" style={{ animationDelay: '0.5s' }}>🏆</div>
+                        </div>
+                        <div className="text-sm md:text-base text-slate-300 font-medium">
+                            Choose your favorite artist and fill out your bracket
+                        </div>
+                        <div className="flex justify-center">
+                            <div className="h-1 w-32 bg-gradient-to-r from-fuchsia-400 via-cyan-400 to-emerald-400 rounded-full shadow-lg"></div>
+                        </div>
+                    </div>
                 </CardHeader>
                 <CardContent className="space-y-4">
                     <div className="space-y-4">
@@ -81,7 +94,7 @@ export default function ArtistBracketPage() {
 
                         <div className="flex flex-col sm:flex-row sm:items-center gap-2">
                             <div className="flex items-center gap-2">
-                                <label htmlFor="bracket-size" className="text-sm text-gray-600 dark:text-gray-400">Bracket size:</label>
+                                <label htmlFor="bracket-size" className="text-sm text-gray-600 dark:text-gray-400">Bracket size: Top </label>
                                 <select
                                     id="bracket-size"
                                     className="border rounded px-2 py-1 bg-white/90 dark:bg-slate-900/60 text-sm"
@@ -92,6 +105,7 @@ export default function ArtistBracketPage() {
                                         <option key={n} value={n}>{n}</option>
                                     ))}
                                 </select>
+                                <label htmlFor="bracket-size" className="text-sm text-gray-600 dark:text-gray-400">songs</label>
                             </div>
                             <Button onClick={generateBracket} disabled={!selected || isSearching || isGenerating} className="relative">
                                 {(isGenerating) ? (
@@ -106,28 +120,54 @@ export default function ArtistBracketPage() {
                                     (isSearching ? 'Loading…' : `Generate ${bracketSize}-Song Bracket`)
                                 )}
                             </Button>
-                            {selected && (
-                                <div className="text-sm text-gray-600 dark:text-gray-400">Selected: <span className="font-medium">{selected.name}</span></div>
-                            )}
                         </div>
 
-                        {seeds.length > 0 && (
-                            <div className="space-y-4">
+                        {isGenerating && (
+                            <div className="flex items-center justify-center py-20">
+                                <div className="text-center space-y-4">
+                                    <div className="relative">
+                                        <div className="w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin mx-auto"></div>
+                                        {/* <div className="absolute inset-0 w-16 h-16 border-4 border-transparent border-r-blue-600 rounded-full animate-spin mx-auto" style={{ animationDirection: 'reverse', animationDuration: '0.8s' }}></div> */}
+                                    </div>
+                                    <div className="text-lg font-semibold text-white">
+                                        Generating your bracket...
+                                    </div>
+                                    <div className="text-sm text-gray-300">
+                                        Fetching most-streamed {bracketSize} songs and creating matchups
+                                    </div>
+                                </div>
+                            </div>
+                        )}
+
+                        {!isGenerating && seeds.length > 0 && (
+                            <div className="space-y-6">
                                 <Bracket seeds={seeds} onChampion={setChampion} onRoundsChange={setRoundsSnapshot} />
                                 {champion && (
-                                    <Card className="p-4 bg-white/80 dark:bg-slate-900/60 backdrop-blur">
-                                        <div className="text-center text-lg">
-                                            <span className="text-gray-600 dark:text-gray-300">Champion:</span> <span className="font-semibold">{champion.name}</span>
-                                        </div>
-                                        <div className="flex justify-center mt-4">
-                                            <Button onClick={() => generateShareImage()}>Download PNG</Button>
-                                        </div>
-                                        {imageUrl && (
-                                            <div className="mt-4">
-                                                {/* eslint-disable-next-line @next/next/no-img-element */}
-                                                <img src={imageUrl} alt="Shareable bracket result" className="max-w-full h-auto mx-auto" />
+                                    <Card className="p-6 bg-gradient-to-br from-emerald-500/20 via-blue-500/20 to-purple-500/20 border-emerald-400/30 shadow-xl">
+                                        <div className="text-center">
+                                            <div className="flex items-center justify-center gap-3 mb-4">
+                                                <div className="text-3xl">🎉</div>
+                                                <h3 className="text-xl md:text-2xl font-bold text-emerald-300">Share Your Results!</h3>
                                             </div>
-                                        )}
+                                            <Button
+                                                onClick={() => generateShareImage()}
+                                                size="lg"
+                                                className="bg-gradient-to-r from-emerald-600 to-blue-600 hover:from-emerald-700 hover:to-blue-700 text-white font-bold py-3 px-8 rounded-xl shadow-lg hover:shadow-xl transition-all"
+                                            >
+                                                <span className="flex items-center gap-2">
+                                                    📸 Download PNG
+                                                </span>
+                                            </Button>
+                                            {imageUrl && (
+                                                <div className="mt-6 p-4 bg-black/20 rounded-xl">
+                                                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                                                    <img src={imageUrl} alt="Shareable bracket result" className="max-w-full h-auto mx-auto rounded-lg shadow-lg" />
+                                                    <div className="mt-4 text-sm text-gray-300">
+                                                        Right-click to save or share on social media!
+                                                    </div>
+                                                </div>
+                                            )}
+                                        </div>
                                     </Card>
                                 )}
                             </div>
@@ -168,94 +208,136 @@ export default function ArtistBracketPage() {
 
 function drawShareImage(opts: { artistName: string; finalFour: TrackSeed[]; champion: TrackSeed }): HTMLCanvasElement {
     const width = 1200;
-    const height = 630;
+    const height = 800;
     const canvas = document.createElement('canvas');
     canvas.width = width;
     canvas.height = height;
     const ctx = canvas.getContext('2d')!;
 
-    // Gradient background
-    const gradient = ctx.createLinearGradient(0, 0, width, height);
-    gradient.addColorStop(0, '#0f172a'); // slate-900
-    gradient.addColorStop(0.5, '#1e293b'); // slate-800
-    gradient.addColorStop(1, '#0f172a');
+    // Modern gradient background
+    const gradient = ctx.createRadialGradient(width / 2, height / 2, 0, width / 2, height / 2, Math.max(width, height) / 2);
+    gradient.addColorStop(0, '#1e293b'); // slate-800
+    gradient.addColorStop(0.7, '#0f172a'); // slate-900
+    gradient.addColorStop(1, '#020617'); // slate-950
     ctx.fillStyle = gradient;
     ctx.fillRect(0, 0, width, height);
 
-    // Accent gradient for title text
-    const titleGradient = ctx.createLinearGradient(40, 40, 700, 100);
+    // Add some visual flair - subtle pattern
+    ctx.globalAlpha = 0.1;
+    for (let i = 0; i < 50; i++) {
+        ctx.beginPath();
+        ctx.arc(Math.random() * width, Math.random() * height, Math.random() * 3 + 1, 0, Math.PI * 2);
+        ctx.fillStyle = '#ffffff';
+        ctx.fill();
+    }
+    ctx.globalAlpha = 1;
+
+    // Title with better spacing
+    const titleGradient = ctx.createLinearGradient(60, 40, 800, 100);
     titleGradient.addColorStop(0, '#f472b6'); // pink-400
     titleGradient.addColorStop(0.5, '#22d3ee'); // cyan-400
     titleGradient.addColorStop(1, '#34d399'); // green-400
 
-    // Title
-    ctx.font = '800 46px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif';
+    ctx.font = 'bold 52px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
     ctx.fillStyle = titleGradient;
-    ctx.fillText('Artist Song Bracket', 40, 70);
+    ctx.fillText('Musician March Madness', 60, 90);
 
-    // Artist label
-    ctx.font = '700 34px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif';
-    ctx.fillStyle = '#93c5fd';
-    wrapText(ctx, `Artist: ${opts.artistName}`, 40, 120, width - 80, 38);
+    // Artist label with better contrast
+    ctx.font = 'bold 32px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
+    ctx.fillStyle = '#e2e8f0'; // slate-200
+    ctx.fillText(`Artist: ${opts.artistName}`, 60, 150);
 
-    // Champion card
-    const cardX = 40;
-    const cardY = 160;
-    const cardW = width - 80;
-    const cardH = 170;
-    // Card background with soft gradient
-    const cardGrad = ctx.createLinearGradient(cardX, cardY, cardX + cardW, cardY + cardH);
-    cardGrad.addColorStop(0, 'rgba(59, 130, 246, 0.25)'); // blue-500/25
-    cardGrad.addColorStop(1, 'rgba(16, 185, 129, 0.25)'); // emerald-500/25
-    ctx.fillStyle = cardGrad;
-    ctx.fillRect(cardX, cardY, cardW, cardH);
-    // Border
-    ctx.strokeStyle = 'rgba(148, 163, 184, 0.4)';
-    ctx.lineWidth = 2;
-    ctx.strokeRect(cardX, cardY, cardW, cardH);
+    // Champion section with better layout
+    const champY = 200;
+    const champH = 180;
 
-    ctx.fillStyle = '#e5e7eb';
-    ctx.font = '800 38px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif';
-    ctx.fillText('Champion', cardX + 20, cardY + 52);
+    // Champion background with rounded corners effect
+    const champGrad = ctx.createLinearGradient(60, champY, width - 60, champY + champH);
+    champGrad.addColorStop(0, 'rgba(253, 224, 71, 0.2)'); // yellow-300/20
+    champGrad.addColorStop(0.5, 'rgba(34, 197, 94, 0.2)'); // green-500/20
+    champGrad.addColorStop(1, 'rgba(59, 130, 246, 0.2)'); // blue-500/20
+
+    ctx.fillStyle = champGrad;
+    roundRect(ctx, 60, champY, width - 120, champH, 20);
+    ctx.fill();
+
+    // Champion border
+    ctx.strokeStyle = 'rgba(253, 224, 71, 0.6)'; // yellow-300/60
+    ctx.lineWidth = 3;
+    roundRect(ctx, 60, champY, width - 120, champH, 20);
+    ctx.stroke();
+
+    // Crown emoji and title
+    ctx.font = 'bold 42px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
+    ctx.fillStyle = '#fbbf24'; // amber-400
+    ctx.fillText('👑 CHAMPION', 80, champY + 50);
+
+    // Champion name with better typography
+    ctx.font = 'bold 36px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
     ctx.fillStyle = '#ffffff';
-    ctx.font = '700 32px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif';
-    wrapText(ctx, opts.champion.name, cardX + 20, cardY + 98, cardW - 40, 36);
+    wrapText(ctx, opts.champion.name, 80, champY + 100, width - 160, 42);
 
-    // Final Four section
-    const ffX = 40;
-    const ffY = 370;
-    const ffW = (width - 80 - 30) / 2;
-    const ffH = 112;
+    // Seed number
+    ctx.font = '24px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
+    ctx.fillStyle = '#fbbf24';
+    ctx.fillText(`Seed #${opts.champion.seed}`, 80, champY + 150);
 
-    ctx.font = '800 28px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif';
-    ctx.fillStyle = '#e5e7eb';
-    ctx.fillText('Final Four', ffX, ffY - 16);
+    // Final Four section with improved spacing
+    const ffY = 420;
+    const ffSpacing = 30;
+    const ffCardW = (width - 120 - ffSpacing) / 2;
+    const ffCardH = 140;
+
+    ctx.font = 'bold 32px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
+    ctx.fillStyle = '#e2e8f0';
+    ctx.fillText('Final Four', 60, ffY - 20);
 
     for (let i = 0; i < Math.min(4, opts.finalFour.length); i++) {
         const row = Math.floor(i / 2);
         const col = i % 2;
-        const x = ffX + col * (ffW + 30);
-        const y = ffY + row * (ffH + 20);
+        const x = 60 + col * (ffCardW + ffSpacing);
+        const y = ffY + row * (ffCardH + 20);
 
-        // Card background
-        ctx.fillStyle = 'rgba(15, 23, 42, 0.8)'; // slate-900/80
-        ctx.fillRect(x, y, ffW, ffH);
-        // Border
-        ctx.strokeStyle = 'rgba(100, 116, 139, 0.6)';
-        ctx.lineWidth = 1.5;
-        ctx.strokeRect(x, y, ffW, ffH);
+        // Card with rounded corners
+        ctx.fillStyle = 'rgba(51, 65, 85, 0.8)'; // slate-700/80
+        roundRect(ctx, x, y, ffCardW, ffCardH, 15);
+        ctx.fill();
+
+        ctx.strokeStyle = 'rgba(148, 163, 184, 0.6)';
+        ctx.lineWidth = 2;
+        roundRect(ctx, x, y, ffCardW, ffCardH, 15);
+        ctx.stroke();
+
+        // Song info
         ctx.fillStyle = '#ffffff';
-        ctx.font = '700 20px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif';
-        wrapText(ctx, `(${opts.finalFour[i].seed}) ${opts.finalFour[i].name}`, x + 16, y + 36, ffW - 32, 26);
+        ctx.font = 'bold 22px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
+        wrapText(ctx, `#${opts.finalFour[i].seed} ${opts.finalFour[i].name}`, x + 20, y + 40, ffCardW - 40, 28);
     }
 
-    // Footer
+    // Footer with better styling
+    ctx.font = '18px system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
     ctx.fillStyle = '#94a3b8';
-    ctx.font = '20px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif';
     const date = new Date().toLocaleDateString();
-    ctx.fillText(`Created on ${date} · djziff.com`, 40, height - 30);
+    const footerText = `Created ${date} • djziff.com`;
+    const footerWidth = ctx.measureText(footerText).width;
+    ctx.fillText(footerText, (width - footerWidth) / 2, height - 40);
 
     return canvas;
+
+    // Helper function for rounded rectangles
+    function roundRect(ctx: CanvasRenderingContext2D, x: number, y: number, width: number, height: number, radius: number) {
+        ctx.beginPath();
+        ctx.moveTo(x + radius, y);
+        ctx.lineTo(x + width - radius, y);
+        ctx.quadraticCurveTo(x + width, y, x + width, y + radius);
+        ctx.lineTo(x + width, y + height - radius);
+        ctx.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
+        ctx.lineTo(x + radius, y + height);
+        ctx.quadraticCurveTo(x, y + height, x, y + height - radius);
+        ctx.lineTo(x, y + radius);
+        ctx.quadraticCurveTo(x, y, x + radius, y);
+        ctx.closePath();
+    }
 }
 
 function wrapText(

--- a/app/(ui)/artist-bracket/page.tsx
+++ b/app/(ui)/artist-bracket/page.tsx
@@ -1,0 +1,288 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import SpotifyAuthCard from '../converter/spotify-auth';
+
+type Artist = {
+    id: string;
+    name: string;
+    images: { url: string; width: number; height: number }[];
+    popularity: number;
+    followers: number;
+};
+
+type TrackSeed = {
+    id: string;
+    name: string;
+    image: string | null;
+    popularity: number;
+    preview_url: string | null;
+    uri: string;
+    seed: number;
+};
+
+type Matchup = {
+    id: string;
+    a: TrackSeed | null;
+    b: TrackSeed | null;
+    winnerId?: string;
+};
+
+function buildInitialRound64(seeds: TrackSeed[]): Matchup[] {
+    const n = seeds.length; // expect 64
+    const matchups: Matchup[] = [];
+    for (let i = 0; i < n / 2; i++) {
+        const top = seeds[i];
+        const bottom = seeds[n - 1 - i];
+        matchups.push({ id: `r64-${i}`, a: top, b: bottom });
+    }
+    return matchups;
+}
+
+function advanceRound(prevRound: Matchup[]): Matchup[] {
+    const winners: (TrackSeed | null)[] = [];
+    for (const m of prevRound) {
+        const winner = m.winnerId === m.a?.id ? m.a : m.winnerId === m.b?.id ? m.b : null;
+        winners.push(winner);
+    }
+    const next: Matchup[] = [];
+    for (let i = 0; i < winners.length; i += 2) {
+        next.push({ id: `${prevRound[0]?.id}-n${i / 2}`, a: winners[i] || null, b: winners[i + 1] || null });
+    }
+    return next;
+}
+
+function Bracket({ seeds, onChampion }: { seeds: TrackSeed[]; onChampion: (t: TrackSeed) => void }) {
+    const [rounds, setRounds] = useState<Matchup[][]>(() => [buildInitialRound64(seeds)]);
+
+    useEffect(() => {
+        setRounds([buildInitialRound64(seeds)]);
+    }, [seeds]);
+
+    const roundNames = ['Round of 64', 'Round of 32', 'Sweet 16', 'Elite 8', 'Final 4', 'Championship'];
+
+    const selectWinner = (roundIndex: number, matchupIndex: number, winnerId: string) => {
+        setRounds((prev) => {
+            const copy = prev.map((r) => r.map((m) => ({ ...m })));
+            copy[roundIndex][matchupIndex].winnerId = winnerId;
+
+            // If round complete, create next round or update next round pairing
+            const currentRound = copy[roundIndex];
+            const isComplete = currentRound.every((m) => !!m.winnerId);
+            const isLastRound = roundIndex === (roundNames.length - 1);
+            if (!isLastRound) {
+                if (!copy[roundIndex + 1]) {
+                    copy[roundIndex + 1] = advanceRound(currentRound);
+                } else {
+                    // Update winners into already created next round
+                    const next = copy[roundIndex + 1];
+                    const pairIndex = Math.floor(matchupIndex / 2);
+                    const isFirst = matchupIndex % 2 === 0;
+                    const winner = currentRound[matchupIndex].winnerId === currentRound[matchupIndex].a?.id
+                        ? currentRound[matchupIndex].a
+                        : currentRound[matchupIndex].b;
+                    if (isFirst) next[pairIndex].a = winner || null; else next[pairIndex].b = winner || null;
+                }
+            }
+
+            if (isComplete && isLastRound) {
+                const finalMatch = currentRound[0];
+                const champ = finalMatch.winnerId === finalMatch.a?.id ? finalMatch.a : finalMatch.b;
+                if (champ) onChampion(champ);
+            }
+
+            return copy;
+        });
+    };
+
+    return (
+        <div className="overflow-x-auto">
+            <div className="grid grid-cols-7 gap-4 min-w-[1200px]">
+                {roundNames.map((title, colIdx) => (
+                    <div key={title} className="space-y-2">
+                        <div className="text-center font-semibold text-sm mb-2">{title}</div>
+                        {(rounds[colIdx] || []).map((m, i) => (
+                            <Card key={m.id} className="p-2">
+                                <div className="flex flex-col gap-2">
+                                    <button
+                                        className={`text-left p-2 rounded border ${m.winnerId === m.a?.id ? 'bg-green-100 dark:bg-green-900/30 border-green-400' : 'hover:bg-gray-50 dark:hover:bg-slate-800'}`}
+                                        onClick={() => m.a && selectWinner(colIdx, i, m.a.id)}
+                                        disabled={!m.a}
+                                    >
+                                        <div className="flex items-center gap-2">
+                                            {m.a?.image && <img src={m.a.image} alt="" className="h-6 w-6 rounded-sm object-cover" />}
+                                            <div className="text-xs">{m.a ? `(${m.a.seed}) ${m.a.name}` : 'TBD'}</div>
+                                        </div>
+                                    </button>
+                                    <button
+                                        className={`text-left p-2 rounded border ${m.winnerId === m.b?.id ? 'bg-green-100 dark:bg-green-900/30 border-green-400' : 'hover:bg-gray-50 dark:hover:bg-slate-800'}`}
+                                        onClick={() => m.b && selectWinner(colIdx, i, m.b.id)}
+                                        disabled={!m.b}
+                                    >
+                                        <div className="flex items-center gap-2">
+                                            {m.b?.image && <img src={m.b.image} alt="" className="h-6 w-6 rounded-sm object-cover" />}
+                                            <div className="text-xs">{m.b ? `(${m.b.seed}) ${m.b.name}` : 'TBD'}</div>
+                                        </div>
+                                    </button>
+                                </div>
+                            </Card>
+                        ))}
+                    </div>
+                ))}
+                <div className="space-y-2">
+                    <div className="text-center font-semibold text-sm mb-2">Winner</div>
+                    <Card className="p-4 text-center">
+                        <div className="text-sm text-gray-600 dark:text-gray-300">Pick winners to decide the champion</div>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default function ArtistBracketPage() {
+    const [isAuthenticated, setIsAuthenticated] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [query, setQuery] = useState('');
+    const [isSearching, setIsSearching] = useState(false);
+    const [results, setResults] = useState<Artist[]>([]);
+    const [selected, setSelected] = useState<Artist | null>(null);
+    const [seeds, setSeeds] = useState<TrackSeed[]>([]);
+    const [champion, setChampion] = useState<TrackSeed | null>(null);
+
+    useEffect(() => {
+        const check = async () => {
+            try {
+                const res = await fetch('/api/check-auth');
+                const data = await res.json();
+                setIsAuthenticated(data.isAuthenticated);
+            } catch (e) {
+                // noop
+            }
+        };
+        check();
+    }, []);
+
+    const initiateSpotifyLogin = async () => {
+        try {
+            const response = await fetch('/api/spotify-callback', {
+                method: 'GET',
+                redirect: 'manual'
+            });
+            if (response.type === 'opaqueredirect') {
+                window.location.href = response.url;
+            }
+        } catch (e) {
+            // noop
+        }
+    };
+
+    useEffect(() => {
+        if (!query.trim()) {
+            setResults([]);
+            return;
+        }
+        const t = setTimeout(async () => {
+            setIsSearching(true);
+            try {
+                const res = await fetch(`/api/spotify-search-artist?q=${encodeURIComponent(query)}`);
+                const data = await res.json();
+                if (res.ok) setResults(data.artists || []);
+                else setResults([]);
+            } catch (_) {
+                setResults([]);
+            } finally {
+                setIsSearching(false);
+            }
+        }, 300);
+        return () => clearTimeout(t);
+    }, [query]);
+
+    const generateBracket = async () => {
+        if (!selected) return;
+        setError(null);
+        setSeeds([]);
+        setChampion(null);
+        try {
+            const res = await fetch(`/api/spotify-artist-tracks?artistId=${selected.id}`);
+            const data = await res.json();
+            if (!res.ok) throw new Error(data?.error || 'Failed to fetch tracks');
+            if (!data.tracks || data.tracks.length < 2) {
+                setError('Not enough songs found to build a bracket.');
+                return;
+            }
+            setSeeds(data.tracks as TrackSeed[]);
+        } catch (e: any) {
+            setError(e.message || 'Error generating bracket');
+        }
+    };
+
+    return (
+        <div className="container mx-auto px-4 py-8 space-y-8">
+            <Card className="max-w-4xl mx-auto">
+                <CardHeader>
+                    <CardTitle>Artist Song Bracket</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    <SpotifyAuthCard error={error} isAuthenticated={isAuthenticated} initiateSpotifyLogin={initiateSpotifyLogin} />
+
+                    {isAuthenticated && (
+                        <div className="space-y-4">
+                            <div className="relative">
+                                <Input
+                                    placeholder="Search for an artist"
+                                    value={query}
+                                    onChange={(e) => setQuery(e.target.value)}
+                                />
+                                {results.length > 0 && (
+                                    <div className="absolute z-10 mt-1 w-full bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-md shadow-md max-h-64 overflow-y-auto">
+                                        {results.map((a) => (
+                                            <button
+                                                key={a.id}
+                                                className="w-full text-left p-2 hover:bg-gray-50 dark:hover:bg-slate-800 flex items-center gap-2"
+                                                onClick={() => {
+                                                    setSelected(a);
+                                                    setQuery(a.name);
+                                                    setResults([]);
+                                                }}
+                                            >
+                                                {a.images?.[a.images.length - 1]?.url && (
+                                                    <img src={a.images[a.images.length - 1].url} alt={a.name} className="h-6 w-6 rounded-sm object-cover" />
+                                                )}
+                                                <span className="text-sm">{a.name}</span>
+                                            </button>
+                                        ))}
+                                    </div>
+                                )}
+                            </div>
+
+                            <div className="flex items-center gap-2">
+                                <Button onClick={generateBracket} disabled={!selected || isSearching}>
+                                    {isSearching ? 'Loading…' : 'Generate 64-Song Bracket'}
+                                </Button>
+                                {selected && (
+                                    <div className="text-sm text-gray-600 dark:text-gray-400">Selected: <span className="font-medium">{selected.name}</span></div>
+                                )}
+                            </div>
+
+                            {seeds.length > 0 && (
+                                <div className="space-y-4">
+                                    <Bracket seeds={seeds} onChampion={setChampion} />
+                                    {champion && (
+                                        <Card className="p-4">
+                                            <div className="text-center">Champion: <span className="font-semibold">{champion.name}</span></div>
+                                        </Card>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    );
+}
+

--- a/app/(ui)/artist-bracket/page.tsx
+++ b/app/(ui)/artist-bracket/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import ArtistSearch from '@/components/search/ArtistSearch';
 import { Button } from '@/components/ui/button';
@@ -10,17 +10,15 @@ import { pickFinalFour, getChampion } from '@/lib/bracket';
 type Artist = {
     id: string;
     name: string;
-    images: { url: string; width: number; height: number }[];
-    popularity: number;
-    followers: number;
+    images: { url: string }[];
 };
 
 import type { TrackSeed, Matchup } from '@/lib/bracket';
 
 export default function ArtistBracketPage() {
-    const [error, setError] = useState<string | null>(null);
+    const [, setError] = useState<string | null>(null);
     const [query, setQuery] = useState('');
-    const [isSearching, setIsSearching] = useState(false);
+    const [isSearching] = useState(false);
     const [selected, setSelected] = useState<Artist | null>(null);
     const [seeds, setSeeds] = useState<TrackSeed[]>([]);
     const [champion, setChampion] = useState<TrackSeed | null>(null);
@@ -28,6 +26,13 @@ export default function ArtistBracketPage() {
     const [imageUrl, setImageUrl] = useState<string | null>(null);
     const [bracketSize, setBracketSize] = useState<number>(8);
     const [isGenerating, setIsGenerating] = useState<boolean>(false);
+
+    // Keep champion in sync with the latest rounds snapshot so it clears/updates
+    // when upstream selections invalidate a previous champion.
+    useEffect(() => {
+        const champ = getChampion(roundsSnapshot);
+        setChampion(champ);
+    }, [roundsSnapshot]);
 
     // search handled by ArtistSearch
 
@@ -59,7 +64,7 @@ export default function ArtistBracketPage() {
                 <CardHeader>
                     <CardTitle>
                         <span className="bg-gradient-to-r from-fuchsia-400 via-cyan-400 to-emerald-400 bg-clip-text text-transparent text-2xl md:text-3xl font-extrabold tracking-tight">
-                            Artist Song Bracket
+                            Musician March Madness
                         </span>
                     </CardTitle>
                 </CardHeader>
@@ -69,7 +74,7 @@ export default function ArtistBracketPage() {
                             value={query}
                             onChange={setQuery}
                             onSelect={(a) => {
-                                setSelected(a as any);
+                                setSelected(a);
                                 setQuery(a.name);
                             }}
                         />
@@ -119,6 +124,7 @@ export default function ArtistBracketPage() {
                                         </div>
                                         {imageUrl && (
                                             <div className="mt-4">
+                                                {/* eslint-disable-next-line @next/next/no-img-element */}
                                                 <img src={imageUrl} alt="Shareable bracket result" className="max-w-full h-auto mx-auto" />
                                             </div>
                                         )}
@@ -152,7 +158,7 @@ export default function ArtistBracketPage() {
             document.body.appendChild(a);
             a.click();
             document.body.removeChild(a);
-        } catch (e) {
+        } catch {
             // ignore
         }
     }

--- a/app/api/spotify-artist-tracks/route.ts
+++ b/app/api/spotify-artist-tracks/route.ts
@@ -1,0 +1,159 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+type SpotifyAlbum = {
+    id: string;
+    album_type: string;
+    total_tracks: number;
+};
+
+type SpotifyTrack = {
+    id: string;
+    name: string;
+    popularity: number;
+    artists: { id: string; name: string }[];
+    album: { images?: { url: string; width: number; height: number }[] };
+    preview_url: string | null;
+    uri: string;
+};
+
+async function fetchAllAlbums(artistId: string, accessToken: string): Promise<SpotifyAlbum[]> {
+    let url = `https://api.spotify.com/v1/artists/${artistId}/albums?include_groups=album,single,compilation,appears_on&market=US&limit=50`;
+    const albums: SpotifyAlbum[] = [];
+    // Cap pages to avoid excessive requests
+    let pagesFetched = 0;
+    const maxPages = 5; // up to 250 albums
+    while (url && pagesFetched < maxPages) {
+        const res = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+        if (!res.ok) break;
+        const data = await res.json();
+        for (const a of data.items || []) {
+            albums.push({ id: a.id, album_type: a.album_type, total_tracks: a.total_tracks });
+        }
+        url = data.next;
+        pagesFetched++;
+    }
+    return albums;
+}
+
+async function fetchAlbumTrackIds(albumId: string, accessToken: string): Promise<string[]> {
+    let url = `https://api.spotify.com/v1/albums/${albumId}/tracks?limit=50&market=US`;
+    const trackIds: string[] = [];
+    while (url) {
+        const res = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+        if (!res.ok) break;
+        const data = await res.json();
+        for (const t of data.items || []) {
+            if (t && t.id) trackIds.push(t.id);
+        }
+        url = data.next;
+    }
+    return trackIds;
+}
+
+async function fetchTracksDetails(trackIds: string[], accessToken: string): Promise<SpotifyTrack[]> {
+    const result: SpotifyTrack[] = [];
+    for (let i = 0; i < trackIds.length; i += 50) {
+        const batch = trackIds.slice(i, i + 50);
+        const res = await fetch(`https://api.spotify.com/v1/tracks?ids=${batch.join(',')}`, {
+            headers: { Authorization: `Bearer ${accessToken}` },
+        });
+        if (!res.ok) continue;
+        const data = await res.json();
+        for (const t of data.tracks || []) {
+            if (!t) continue;
+            result.push({
+                id: t.id,
+                name: t.name,
+                popularity: t.popularity,
+                artists: (t.artists || []).map((a: any) => ({ id: a.id, name: a.name })),
+                album: { images: t.album?.images || [] },
+                preview_url: t.preview_url,
+                uri: t.uri,
+            });
+        }
+    }
+    return result;
+}
+
+function normalizeTitle(name: string): string {
+    return name
+        .toLowerCase()
+        .replace(/\s*\([^)]*(remaster|live|edit|version|mono|stereo|deluxe)[^)]*\)\s*/gi, ' ')
+        .replace(/-\s*(remaster|live|edit|version).*/gi, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+export async function GET(request: NextRequest) {
+    const artistId = request.nextUrl.searchParams.get('artistId');
+    if (!artistId) {
+        return NextResponse.json({ error: 'Missing artistId' }, { status: 400 });
+    }
+
+    const accessToken = request.cookies.get('spotify_access_token')?.value;
+    if (!accessToken) {
+        return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+    }
+
+    try {
+        const albums = await fetchAllAlbums(artistId, accessToken);
+        // Prefer albums and singles first
+        const prioritized = [
+            ...albums.filter(a => a.album_type === 'album'),
+            ...albums.filter(a => a.album_type === 'single'),
+            ...albums.filter(a => a.album_type === 'compilation'),
+            ...albums.filter(a => a.album_type === 'appears_on'),
+        ];
+
+        const seenTrackIds = new Set<string>();
+        const allTrackIds: string[] = [];
+
+        for (const album of prioritized) {
+            const ids = await fetchAlbumTrackIds(album.id, accessToken);
+            for (const id of ids) {
+                if (!seenTrackIds.has(id)) {
+                    seenTrackIds.add(id);
+                    allTrackIds.push(id);
+                }
+            }
+            if (allTrackIds.length >= 300) break; // cap
+        }
+
+        const tracks = await fetchTracksDetails(allTrackIds, accessToken);
+
+        // Keep tracks where the artist is one of the artists on the track
+        const filtered = tracks.filter(t => t.artists.some(a => a.id === artistId));
+
+        // Deduplicate by normalized title to avoid duplicates across versions; keep highest popularity
+        const titleToTrack = new Map<string, SpotifyTrack>();
+        for (const t of filtered) {
+            const key = normalizeTitle(t.name);
+            const existing = titleToTrack.get(key);
+            if (!existing || t.popularity > existing.popularity) {
+                titleToTrack.set(key, t);
+            }
+        }
+
+        const uniqueTracks = Array.from(titleToTrack.values());
+
+        uniqueTracks.sort((a, b) => b.popularity - a.popularity);
+
+        const top64 = uniqueTracks.slice(0, 64);
+
+        const simplified = top64.map((t, index) => ({
+            id: t.id,
+            name: t.name,
+            popularity: t.popularity,
+            image: t.album.images?.[0]?.url || null,
+            preview_url: t.preview_url,
+            uri: t.uri,
+            seed: index + 1,
+        }));
+
+        return NextResponse.json({ tracks: simplified });
+    } catch (e: any) {
+        console.error(e);
+        return NextResponse.json({ error: 'Failed to load artist tracks' }, { status: 500 });
+    }
+}
+

--- a/app/api/spotify-artist-tracks/route.ts
+++ b/app/api/spotify-artist-tracks/route.ts
@@ -85,7 +85,7 @@ async function fetchTracksDetails(trackIds: string[], accessToken: string): Prom
                 id: t.id,
                 name: t.name,
                 popularity: t.popularity,
-                artists: (t.artists || []).map((a: any) => ({ id: a.id, name: a.name })),
+                artists: (t.artists || []).map((a: { id: string; name: string }) => ({ id: a.id, name: a.name })),
                 album: { images: t.album?.images || [] },
                 preview_url: t.preview_url,
                 uri: t.uri,
@@ -114,10 +114,7 @@ export async function GET(request: NextRequest) {
     const desiredSize = Math.max(8, Math.min(64, Number(sizeParam) || 64));
     const requestedSize = allowedSizes.includes(desiredSize) ? desiredSize : 64;
 
-    let accessToken = request.cookies.get('spotify_access_token')?.value;
-    if (!accessToken) {
-        accessToken = await getAppAccessToken();
-    }
+    const accessToken = await getAppAccessToken();
     if (!accessToken) return NextResponse.json({ error: 'Spotify auth unavailable' }, { status: 503 });
 
     try {
@@ -186,7 +183,7 @@ export async function GET(request: NextRequest) {
         }));
 
         return NextResponse.json({ tracks: simplified });
-    } catch (e: any) {
+    } catch (e: unknown) {
         console.error(e);
         return NextResponse.json({ error: 'Failed to load artist tracks' }, { status: 500 });
     }

--- a/app/api/spotify-artist-tracks/route.ts
+++ b/app/api/spotify-artist-tracks/route.ts
@@ -1,5 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+async function getAppAccessToken(): Promise<string | null> {
+    try {
+        const clientId = process.env.SPOTIFY_CLIENT_ID!;
+        const clientSecret = process.env.SPOTIFY_CLIENT_SECRET!;
+        const response = await fetch('https://accounts.spotify.com/api/token', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'Authorization': `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
+            },
+            body: new URLSearchParams({ grant_type: 'client_credentials' }),
+        });
+        if (!response.ok) return null;
+        const data = await response.json();
+        return data.access_token || null;
+    } catch {
+        return null;
+    }
+}
+
 type SpotifyAlbum = {
     id: string;
     album_type: string;
@@ -86,14 +106,19 @@ function normalizeTitle(name: string): string {
 
 export async function GET(request: NextRequest) {
     const artistId = request.nextUrl.searchParams.get('artistId');
+    const sizeParam = request.nextUrl.searchParams.get('size');
     if (!artistId) {
         return NextResponse.json({ error: 'Missing artistId' }, { status: 400 });
     }
+    const allowedSizes = [8, 16, 32, 64];
+    const desiredSize = Math.max(8, Math.min(64, Number(sizeParam) || 64));
+    const requestedSize = allowedSizes.includes(desiredSize) ? desiredSize : 64;
 
-    const accessToken = request.cookies.get('spotify_access_token')?.value;
+    let accessToken = request.cookies.get('spotify_access_token')?.value;
     if (!accessToken) {
-        return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+        accessToken = await getAppAccessToken();
     }
+    if (!accessToken) return NextResponse.json({ error: 'Spotify auth unavailable' }, { status: 503 });
 
     try {
         const albums = await fetchAllAlbums(artistId, accessToken);
@@ -138,9 +163,19 @@ export async function GET(request: NextRequest) {
 
         uniqueTracks.sort((a, b) => b.popularity - a.popularity);
 
-        const top64 = uniqueTracks.slice(0, 64);
+        // Pick the largest allowed size that is <= requestedSize and <= available tracks
+        const available = uniqueTracks.length;
+        const effectiveSize = allowedSizes
+            .filter((n) => n <= requestedSize && n <= available)
+            .sort((a, b) => b - a)[0];
 
-        const simplified = top64.map((t, index) => ({
+        if (!effectiveSize) {
+            return NextResponse.json({ error: 'Not enough songs found to build a bracket.' }, { status: 400 });
+        }
+
+        const topN = uniqueTracks.slice(0, effectiveSize);
+
+        const simplified = topN.map((t, index) => ({
             id: t.id,
             name: t.name,
             popularity: t.popularity,

--- a/app/api/spotify-search-artist/route.ts
+++ b/app/api/spotify-search-artist/route.ts
@@ -28,10 +28,7 @@ export async function GET(request: NextRequest) {
         return NextResponse.json({ error: 'No search query provided' }, { status: 400 });
     }
 
-    let accessToken = request.cookies.get('spotify_access_token')?.value;
-    if (!accessToken) {
-        accessToken = await getAppAccessToken();
-    }
+    const accessToken = await getAppAccessToken();
     if (!accessToken) return NextResponse.json({ error: 'Spotify auth unavailable' }, { status: 503 });
 
     try {

--- a/app/api/spotify-search-artist/route.ts
+++ b/app/api/spotify-search-artist/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+    const searchParams = request.nextUrl.searchParams;
+    const query = searchParams.get('q');
+
+    if (!query) {
+        return NextResponse.json({ error: 'No search query provided' }, { status: 400 });
+    }
+
+    const accessToken = request.cookies.get('spotify_access_token')?.value;
+
+    if (!accessToken) {
+        return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+    }
+
+    try {
+        const response = await fetch(
+            `https://api.spotify.com/v1/search?q=${encodeURIComponent(query)}&type=artist&limit=10`,
+            {
+                headers: {
+                    'Authorization': `Bearer ${accessToken}`
+                }
+            }
+        );
+
+        if (!response.ok) {
+            const text = await response.text();
+            return NextResponse.json({ error: 'Spotify search failed', details: text }, { status: response.status });
+        }
+
+        const data = await response.json();
+
+        const artists = (data.artists?.items || []).map((a: any) => ({
+            id: a.id,
+            name: a.name,
+            images: a.images || [],
+            popularity: a.popularity,
+            followers: a.followers?.total ?? 0,
+        }));
+
+        return NextResponse.json({ artists });
+    } catch (error) {
+        console.log(error);
+        return NextResponse.json({ error: 'Search failed' }, { status: 500 });
+    }
+}
+

--- a/app/api/spotify-search-artist/route.ts
+++ b/app/api/spotify-search-artist/route.ts
@@ -1,5 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+async function getAppAccessToken(): Promise<string | null> {
+    try {
+        const clientId = process.env.SPOTIFY_CLIENT_ID!;
+        const clientSecret = process.env.SPOTIFY_CLIENT_SECRET!;
+        const response = await fetch('https://accounts.spotify.com/api/token', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'Authorization': `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
+            },
+            body: new URLSearchParams({ grant_type: 'client_credentials' }),
+        });
+        if (!response.ok) return null;
+        const data = await response.json();
+        return data.access_token || null;
+    } catch {
+        return null;
+    }
+}
+
 export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
     const query = searchParams.get('q');
@@ -8,11 +28,11 @@ export async function GET(request: NextRequest) {
         return NextResponse.json({ error: 'No search query provided' }, { status: 400 });
     }
 
-    const accessToken = request.cookies.get('spotify_access_token')?.value;
-
+    let accessToken = request.cookies.get('spotify_access_token')?.value;
     if (!accessToken) {
-        return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+        accessToken = await getAppAccessToken();
     }
+    if (!accessToken) return NextResponse.json({ error: 'Spotify auth unavailable' }, { status: 503 });
 
     try {
         const response = await fetch(

--- a/app/api/spotify-search-artist/route.ts
+++ b/app/api/spotify-search-artist/route.ts
@@ -48,7 +48,7 @@ export async function GET(request: NextRequest) {
 
         const data = await response.json();
 
-        const artists = (data.artists?.items || []).map((a: any) => ({
+        const artists = (data.artists?.items || []).map((a: { id: string; name: string; images?: { url: string }[]; popularity?: number; followers?: { total?: number } }) => ({
             id: a.id,
             name: a.name,
             images: a.images || [],

--- a/app/api/spotify-search/route.ts
+++ b/app/api/spotify-search/route.ts
@@ -28,10 +28,7 @@ export async function GET(request: NextRequest) {
         return NextResponse.json({ error: 'No search query provided' }, { status: 400 });
     }
 
-    let accessToken = request.cookies.get('spotify_access_token')?.value;
-    if (!accessToken) {
-        accessToken = await getAppAccessToken();
-    }
+    const accessToken = await getAppAccessToken();
     if (!accessToken) return NextResponse.json({ error: 'Spotify auth unavailable' }, { status: 503 });
 
     try {

--- a/app/api/spotify-search/route.ts
+++ b/app/api/spotify-search/route.ts
@@ -1,5 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+async function getAppAccessToken(): Promise<string | null> {
+    try {
+        const clientId = process.env.SPOTIFY_CLIENT_ID!;
+        const clientSecret = process.env.SPOTIFY_CLIENT_SECRET!;
+        const response = await fetch('https://accounts.spotify.com/api/token', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'Authorization': `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
+            },
+            body: new URLSearchParams({ grant_type: 'client_credentials' }),
+        });
+        if (!response.ok) return null;
+        const data = await response.json();
+        return data.access_token || null;
+    } catch {
+        return null;
+    }
+}
+
 export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
     const query = searchParams.get('q');
@@ -8,11 +28,11 @@ export async function GET(request: NextRequest) {
         return NextResponse.json({ error: 'No search query provided' }, { status: 400 });
     }
 
-    const accessToken = request.cookies.get('spotify_access_token')?.value;
-
+    let accessToken = request.cookies.get('spotify_access_token')?.value;
     if (!accessToken) {
-        return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+        accessToken = await getAppAccessToken();
     }
+    if (!accessToken) return NextResponse.json({ error: 'Spotify auth unavailable' }, { status: 503 });
 
     try {
         const response = await fetch(

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,7 +10,10 @@ export default function Home() {
         <Link href={'/converter'}>
           <h1 className="underline hover:opacity-70 transition-opacity">1. .M3U8 TO SPOTIFY</h1>
         </Link>
-        <h1>2. PARTY PLANNER CHATBOT</h1>
+        <Link href={'/artist-bracket'}>
+          <h1 className="underline hover:opacity-70 transition-opacity">2. ARTIST SONG BRACKET</h1>
+        </Link>
+        <h1>3. PARTY PLANNER CHATBOT</h1>
         <h1> - DJ ZIFF</h1>
         {/* <Image
           className="dark:invert"

--- a/components/bracket/Bracket.tsx
+++ b/components/bracket/Bracket.tsx
@@ -1,0 +1,103 @@
+"use client";
+import { useEffect, useMemo, useState } from "react";
+import { Card } from "@/components/ui/card";
+import Image from "next/image";
+import type { Matchup, TrackSeed } from "@/lib/bracket";
+import { advanceRound, buildInitialRound, computeRoundNames, propagateWinnerChange } from "@/lib/bracket";
+
+export function Bracket({ seeds, onChampion, onRoundsChange }: { seeds: TrackSeed[]; onChampion: (t: TrackSeed) => void; onRoundsChange?: (rounds: Matchup[][]) => void }) {
+    const [rounds, setRounds] = useState<Matchup[][]>(() => [buildInitialRound(seeds)]);
+
+    const totalRounds = useMemo(() => Math.max(1, Math.log2(Math.max(1, seeds.length))), [seeds.length]);
+    const roundNames = useMemo(() => computeRoundNames(seeds.length), [seeds.length]);
+
+    useEffect(() => {
+        const initial = [buildInitialRound(seeds)];
+        setRounds(initial);
+        // Build subsequent empty rounds structure
+        const roundsCount = Math.max(1, Math.log2(Math.max(1, seeds.length)));
+        let current = initial[0];
+        const full: Matchup[][] = [current];
+        for (let i = 1; i < roundsCount; i++) {
+            const next = advanceRound(current);
+            full.push(next);
+            current = next;
+        }
+        setRounds(full);
+    }, [seeds]);
+
+    useEffect(() => {
+        onRoundsChange?.(rounds);
+    }, [rounds, onRoundsChange]);
+
+    useEffect(() => {
+        const lastRound = rounds[rounds.length - 1];
+        if (!lastRound || lastRound.length === 0) return;
+        const finalMatch = lastRound[0];
+        if (!finalMatch?.winnerId) return;
+        const champ = finalMatch.winnerId === finalMatch.a?.id ? finalMatch.a : finalMatch.b;
+        if (champ) onChampion(champ);
+    }, [rounds, onChampion]);
+
+    const selectWinner = (roundIndex: number, matchupIndex: number, winnerId: string) => {
+        setRounds((prev) => {
+            const copy = prev.map((r) => r.map((m) => ({ ...m })));
+            copy[roundIndex][matchupIndex].winnerId = winnerId;
+
+            // Ensure next round exists
+            if (!copy[roundIndex + 1] && roundIndex < totalRounds - 1) {
+                copy[roundIndex + 1] = advanceRound(copy[roundIndex]);
+            }
+
+            // Propagate only along the path from this matchup forward
+            const updated = propagateWinnerChange(copy, roundIndex, matchupIndex);
+            return updated;
+        });
+    };
+
+    return (
+        <div className="overflow-x-auto">
+            <div className="grid gap-3 md:gap-4 min-w-[900px] md:min-w-[1200px]" style={{ gridTemplateColumns: `repeat(${roundNames.length}, minmax(0, 1fr))` }}>
+                {roundNames.map((title, colIdx) => (
+                    <div key={title} className="space-y-2">
+                        <div className="text-center font-semibold text-xs md:text-sm mb-2">{title}</div>
+                        {(rounds[colIdx] || []).map((m, i) => (
+                            <Card key={m.id} className="p-2 bg-white/70 dark:bg-slate-900/50 backdrop-blur border-slate-200/60 dark:border-slate-700/60 shadow-sm">
+                                <div className="flex flex-col gap-2">
+                                    <button
+                                        className={`text-left p-2 rounded border text-xs md:text-sm ${m.winnerId === m.a?.id ? 'bg-green-100 dark:bg-green-900/30 border-green-400' : 'hover:bg-gray-50 dark:hover:bg-slate-800'}`}
+                                        onClick={() => m.a && selectWinner(colIdx, i, m.a.id)}
+                                        disabled={!m.a}
+                                    >
+                                        <div className="flex items-center gap-2">
+                                            {m.a?.image && (
+                                                <Image src={m.a.image} alt="" width={24} height={24} className="h-5 w-5 md:h-6 md:w-6 rounded-sm object-cover" />
+                                            )}
+                                            <div className="text-[10px] md:text-xs">{m.a ? `(${m.a.seed}) ${m.a.name}` : 'TBD'}</div>
+                                        </div>
+                                    </button>
+                                    <button
+                                        className={`text-left p-2 rounded border text-xs md:text-sm ${m.winnerId === m.b?.id ? 'bg-green-100 dark:bg-green-900/30 border-green-400' : 'hover:bg-gray-50 dark:hover:bg-slate-800'}`}
+                                        onClick={() => m.b && selectWinner(colIdx, i, m.b.id)}
+                                        disabled={!m.b}
+                                    >
+                                        <div className="flex items-center gap-2">
+                                            {m.b?.image && (
+                                                <Image src={m.b.image} alt="" width={24} height={24} className="h-5 w-5 md:h-6 md:w-6 rounded-sm object-cover" />
+                                            )}
+                                            <div className="text-[10px] md:text-xs">{m.b ? `(${m.b.seed}) ${m.b.name}` : 'TBD'}</div>
+                                        </div>
+                                    </button>
+                                </div>
+                            </Card>
+                        ))}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+export default Bracket;
+
+

--- a/components/bracket/Bracket.tsx
+++ b/components/bracket/Bracket.tsx
@@ -1,11 +1,11 @@
 "use client";
-import { useEffect, useMemo, useState } from "react";
+import { ReactNode, useEffect, useMemo, useState } from "react";
 import { Card } from "@/components/ui/card";
 import Image from "next/image";
 import type { Matchup, TrackSeed } from "@/lib/bracket";
 import { advanceRound, buildInitialRound, computeRoundNames, propagateWinnerChange } from "@/lib/bracket";
 
-export function Bracket({ seeds, onChampion, onRoundsChange }: { seeds: TrackSeed[]; onChampion: (t: TrackSeed) => void; onRoundsChange?: (rounds: Matchup[][]) => void }) {
+export function Bracket({ seeds, onChampion, onRoundsChange, renderBelowChampion }: { seeds: TrackSeed[]; onChampion: (t: TrackSeed | null) => void; onRoundsChange?: (rounds: Matchup[][]) => void; renderBelowChampion?: ReactNode }) {
     const [rounds, setRounds] = useState<Matchup[][]>(() => [buildInitialRound(seeds)]);
 
     const totalRounds = useMemo(() => Math.max(1, Math.log2(Math.max(1, seeds.length))), [seeds.length]);
@@ -32,11 +32,17 @@ export function Bracket({ seeds, onChampion, onRoundsChange }: { seeds: TrackSee
 
     useEffect(() => {
         const lastRound = rounds[rounds.length - 1];
-        if (!lastRound || lastRound.length === 0) return;
+        if (!lastRound || lastRound.length === 0) {
+            onChampion(null);
+            return;
+        }
         const finalMatch = lastRound[0];
-        if (!finalMatch?.winnerId) return;
+        if (!finalMatch?.winnerId) {
+            onChampion(null);
+            return;
+        }
         const champ = finalMatch.winnerId === finalMatch.a?.id ? finalMatch.a : finalMatch.b;
-        if (champ) onChampion(champ);
+        onChampion(champ);
     }, [rounds, onChampion]);
 
     const selectWinner = (roundIndex: number, matchupIndex: number, winnerId: string) => {
@@ -96,6 +102,8 @@ export function Bracket({ seeds, onChampion, onRoundsChange }: { seeds: TrackSee
                     </div>
                 </Card>
             </div>
+
+            {renderBelowChampion}
 
             {/* Bracket Grid */}
             <div className="overflow-x-auto pb-4">

--- a/components/bracket/Bracket.tsx
+++ b/components/bracket/Bracket.tsx
@@ -55,44 +55,136 @@ export function Bracket({ seeds, onChampion, onRoundsChange }: { seeds: TrackSee
         });
     };
 
+    // Check for champion to show prominent display
+    const currentChampion = useMemo(() => {
+        const lastRound = rounds[rounds.length - 1];
+        if (!lastRound || lastRound.length === 0) return null;
+        const finalMatch = lastRound[0];
+        if (!finalMatch?.winnerId) return null;
+        return finalMatch.winnerId === finalMatch.a?.id ? finalMatch.a : finalMatch.b;
+    }, [rounds]);
+
     return (
-        <div className="overflow-x-auto">
-            <div className="grid gap-3 md:gap-4 min-w-[900px] md:min-w-[1200px]" style={{ gridTemplateColumns: `repeat(${roundNames.length}, minmax(0, 1fr))` }}>
-                {roundNames.map((title, colIdx) => (
-                    <div key={title} className="space-y-2">
-                        <div className="text-center font-semibold text-xs md:text-sm mb-2">{title}</div>
-                        {(rounds[colIdx] || []).map((m, i) => (
-                            <Card key={m.id} className="p-2 bg-white/70 dark:bg-slate-900/50 backdrop-blur border-slate-200/60 dark:border-slate-700/60 shadow-sm">
-                                <div className="flex flex-col gap-2">
-                                    <button
-                                        className={`text-left p-2 rounded border text-xs md:text-sm ${m.winnerId === m.a?.id ? 'bg-green-100 dark:bg-green-900/30 border-green-400' : 'hover:bg-gray-50 dark:hover:bg-slate-800'}`}
-                                        onClick={() => m.a && selectWinner(colIdx, i, m.a.id)}
-                                        disabled={!m.a}
-                                    >
-                                        <div className="flex items-center gap-2">
-                                            {m.a?.image && (
-                                                <Image src={m.a.image} alt="" width={24} height={24} className="h-5 w-5 md:h-6 md:w-6 rounded-sm object-cover" />
-                                            )}
-                                            <div className="text-[10px] md:text-xs">{m.a ? `(${m.a.seed}) ${m.a.name}` : 'TBD'}</div>
-                                        </div>
-                                    </button>
-                                    <button
-                                        className={`text-left p-2 rounded border text-xs md:text-sm ${m.winnerId === m.b?.id ? 'bg-green-100 dark:bg-green-900/30 border-green-400' : 'hover:bg-gray-50 dark:hover:bg-slate-800'}`}
-                                        onClick={() => m.b && selectWinner(colIdx, i, m.b.id)}
-                                        disabled={!m.b}
-                                    >
-                                        <div className="flex items-center gap-2">
-                                            {m.b?.image && (
-                                                <Image src={m.b.image} alt="" width={24} height={24} className="h-5 w-5 md:h-6 md:w-6 rounded-sm object-cover" />
-                                            )}
-                                            <div className="text-[10px] md:text-xs">{m.b ? `(${m.b.seed}) ${m.b.name}` : 'TBD'}</div>
-                                        </div>
-                                    </button>
+        <div className="space-y-6">
+            {/* Champion Display - Always visible and prominent */}
+            <div className="relative">
+                <Card className="p-6 bg-gradient-to-br from-yellow-500/20 via-orange-500/20 to-red-500/20 border-yellow-400/30 shadow-xl">
+                    <div className="text-center">
+                        <div className="flex items-center justify-center gap-2 mb-3">
+                            <div className="text-2xl">👑</div>
+                            <h3 className="text-xl md:text-2xl font-bold text-yellow-300">Champion</h3>
+                        </div>
+                        {currentChampion ? (
+                            <div className="flex items-center justify-center gap-4 p-4 bg-black/20 rounded-lg">
+                                {currentChampion.image && (
+                                    <Image
+                                        src={currentChampion.image}
+                                        alt={currentChampion.name}
+                                        width={64}
+                                        height={64}
+                                        className="h-12 w-12 md:h-16 md:w-16 rounded-lg object-cover shadow-lg"
+                                    />
+                                )}
+                                <div className="text-left">
+                                    <div className="text-lg md:text-xl font-bold text-white">{currentChampion.name}</div>
+                                    <div className="text-sm text-yellow-200">Seed #{currentChampion.seed}</div>
                                 </div>
-                            </Card>
-                        ))}
+                            </div>
+                        ) : (
+                            <div className="text-gray-400 text-lg">Complete the bracket to crown your favorite song</div>
+                        )}
                     </div>
-                ))}
+                </Card>
+            </div>
+
+            {/* Bracket Grid */}
+            <div className="overflow-x-auto pb-4">
+                <div className="grid gap-4 md:gap-6 min-w-fit" style={{ gridTemplateColumns: `repeat(${roundNames.length}, minmax(240px, 1fr))` }}>
+                    {roundNames.map((title, colIdx) => (
+                        <div key={title} className="space-y-4">
+                            <div className="text-center font-bold text-sm md:text-lg mb-4 text-white bg-gradient-to-r from-purple-600 to-blue-600 py-2 px-4 rounded-lg shadow-lg">
+                                {title}
+                            </div>
+                            <div className="space-y-3">
+                                {(rounds[colIdx] || []).map((m, i) => (
+                                    <Card key={m.id} className="p-3 bg-white/90 dark:bg-slate-800/90 backdrop-blur border-2 border-slate-300/80 dark:border-slate-600/80 shadow-lg hover:shadow-xl transition-all">
+                                        <div className="space-y-2">
+                                            <button
+                                                className={`w-full text-left p-3 rounded-lg border-2 transition-all text-sm md:text-base ${!m.a
+                                                    ? 'bg-gray-100 dark:bg-gray-800/50 border-gray-300 dark:border-gray-600 cursor-not-allowed'
+                                                    : m.winnerId === m.a?.id
+                                                        ? 'bg-green-100 dark:bg-green-900/40 border-green-400 shadow-lg transform scale-[1.02]'
+                                                        : 'hover:bg-gray-50 dark:hover:bg-slate-700 border-gray-200 dark:border-slate-600 hover:border-blue-300 dark:hover:border-blue-500'
+                                                    }`}
+                                                onClick={() => m.a && selectWinner(colIdx, i, m.a.id)}
+                                                disabled={!m.a}
+                                            >
+                                                <div className="flex items-center gap-3">
+                                                    {m.a?.image && (
+                                                        <Image
+                                                            src={m.a.image}
+                                                            alt=""
+                                                            width={40}
+                                                            height={40}
+                                                            className="h-8 w-8 md:h-10 md:w-10 rounded-md object-cover shadow-sm"
+                                                        />
+                                                    )}
+                                                    <div className="flex-1 min-w-0">
+                                                        <div className={`font-medium truncate ${!m.a ? 'text-gray-500 dark:text-gray-400' : 'text-gray-900 dark:text-gray-100'}`}>
+                                                            {m.a ? m.a.name : 'TBD'}
+                                                        </div>
+                                                        {m.a && (
+                                                            <div className="text-xs text-gray-500 dark:text-gray-400">Seed #{m.a.seed}</div>
+                                                        )}
+                                                    </div>
+                                                    {m.winnerId === m.a?.id && m.a && (
+                                                        <div className="text-green-600 dark:text-green-400 text-xl">✓</div>
+                                                    )}
+                                                </div>
+                                            </button>
+
+                                            <div className="text-center text-xs text-gray-400 font-medium">VS</div>
+
+                                            <button
+                                                className={`w-full text-left p-3 rounded-lg border-2 transition-all text-sm md:text-base ${!m.b
+                                                    ? 'bg-gray-100 dark:bg-gray-800/50 border-gray-300 dark:border-gray-600 cursor-not-allowed'
+                                                    : m.winnerId === m.b?.id
+                                                        ? 'bg-green-100 dark:bg-green-900/40 border-green-400 shadow-lg transform scale-[1.02]'
+                                                        : 'hover:bg-gray-50 dark:hover:bg-slate-700 border-gray-200 dark:border-slate-600 hover:border-blue-300 dark:hover:border-blue-500'
+                                                    }`}
+                                                onClick={() => m.b && selectWinner(colIdx, i, m.b.id)}
+                                                disabled={!m.b}
+                                            >
+                                                <div className="flex items-center gap-3">
+                                                    {m.b?.image && (
+                                                        <Image
+                                                            src={m.b.image}
+                                                            alt=""
+                                                            width={40}
+                                                            height={40}
+                                                            className="h-8 w-8 md:h-10 md:w-10 rounded-md object-cover shadow-sm"
+                                                        />
+                                                    )}
+                                                    <div className="flex-1 min-w-0">
+                                                        <div className={`font-medium truncate ${!m.b ? 'text-gray-500 dark:text-gray-400' : 'text-gray-900 dark:text-gray-100'}`}>
+                                                            {m.b ? m.b.name : 'TBD'}
+                                                        </div>
+                                                        {m.b && (
+                                                            <div className="text-xs text-gray-500 dark:text-gray-400">Seed #{m.b.seed}</div>
+                                                        )}
+                                                    </div>
+                                                    {m.winnerId === m.b?.id && m.b && (
+                                                        <div className="text-green-600 dark:text-green-400 text-xl">✓</div>
+                                                    )}
+                                                </div>
+                                            </button>
+                                        </div>
+                                    </Card>
+                                ))}
+                            </div>
+                        </div>
+                    ))}
+                </div>
             </div>
         </div>
     );

--- a/components/search/ArtistSearch.tsx
+++ b/components/search/ArtistSearch.tsx
@@ -1,0 +1,80 @@
+"use client";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Input } from "@/components/ui/input";
+import Image from "next/image";
+
+type Artist = {
+    id: string;
+    name: string;
+    images: { url: string }[];
+};
+
+export function ArtistSearch({ value, onChange, onSelect }: { value: string; onChange: (v: string) => void; onSelect: (artist: Artist) => void }) {
+    const [results, setResults] = useState<Artist[]>([]);
+    const [isSearching, setIsSearching] = useState(false);
+    const suppressNextSearchRef = useRef(false);
+
+    // Debounced search
+    useEffect(() => {
+        const q = value.trim();
+        if (!q) {
+            setResults([]);
+            return;
+        }
+
+        if (suppressNextSearchRef.current) {
+            suppressNextSearchRef.current = false;
+            return;
+        }
+
+        const t = setTimeout(async () => {
+            setIsSearching(true);
+            try {
+                const res = await fetch(`/api/spotify-search-artist?q=${encodeURIComponent(q)}`);
+                const data = await res.json();
+                if (res.ok) setResults(data.artists || []);
+                else setResults([]);
+            } catch {
+                setResults([]);
+            } finally {
+                setIsSearching(false);
+            }
+        }, 250);
+        return () => clearTimeout(t);
+    }, [value]);
+
+    return (
+        <div className="relative">
+            <Input
+                placeholder="Search for an artist"
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                className="bg-white/90 dark:bg-slate-900/60 border-slate-200/50 dark:border-slate-700/60"
+            />
+            {results.length > 0 && (
+                <div className="absolute z-10 mt-1 w-full bg-white/95 dark:bg-slate-900/95 border border-gray-200 dark:border-slate-700 rounded-md shadow-md max-h-64 overflow-y-auto">
+                    {results.map((a) => (
+                        <button
+                            key={a.id}
+                            className="w-full text-left p-2 hover:bg-gray-50 dark:hover:bg-slate-800 flex items-center gap-2"
+                            onClick={() => {
+                                suppressNextSearchRef.current = true;
+                                setResults([]); // close dropdown immediately
+                                onSelect(a);
+                            }}
+                        >
+                            {a.images?.[a.images.length - 1]?.url && (
+                                <Image src={a.images[a.images.length - 1].url} alt={a.name} width={24} height={24} className="h-6 w-6 rounded-sm object-cover" />
+                            )}
+                            <span className="text-sm">{a.name}</span>
+                        </button>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+export default ArtistSearch;
+
+

--- a/components/search/ArtistSearch.tsx
+++ b/components/search/ArtistSearch.tsx
@@ -44,7 +44,7 @@ export function ArtistSearch({ value, onChange, onSelect }: { value: string; onC
     }, [value]);
 
     return (
-        <div className="relative">
+        <div className="relative z-50">
             <Input
                 placeholder="Search for an artist"
                 value={value}
@@ -52,7 +52,7 @@ export function ArtistSearch({ value, onChange, onSelect }: { value: string; onC
                 className="bg-white/90 dark:bg-slate-900/60 border-slate-200/50 dark:border-slate-700/60"
             />
             {results.length > 0 && (
-                <div className="absolute z-10 mt-1 w-full bg-white/95 dark:bg-slate-900/95 border border-gray-200 dark:border-slate-700 rounded-md shadow-md max-h-64 overflow-y-auto">
+                <div className="absolute z-10 mt-1 w-full bg-white/95 dark:bg-slate-900/95 border border-gray-200 dark:border-slate-700 rounded-md shadow-md max-h-80 overflow-y-auto">
                     {results.map((a) => (
                         <button
                             key={a.id}

--- a/components/search/ArtistSearch.tsx
+++ b/components/search/ArtistSearch.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Input } from "@/components/ui/input";
 import Image from "next/image";
 
@@ -11,7 +11,7 @@ type Artist = {
 
 export function ArtistSearch({ value, onChange, onSelect }: { value: string; onChange: (v: string) => void; onSelect: (artist: Artist) => void }) {
     const [results, setResults] = useState<Artist[]>([]);
-    const [isSearching, setIsSearching] = useState(false);
+    const [, setIsSearching] = useState(false);
     const suppressNextSearchRef = useRef(false);
 
     // Debounced search

--- a/lib/bracket.ts
+++ b/lib/bracket.ts
@@ -1,0 +1,114 @@
+export type TrackSeed = {
+    id: string;
+    name: string;
+    image: string | null;
+    popularity: number;
+    preview_url: string | null;
+    uri: string;
+    seed: number;
+};
+
+export type Matchup = {
+    id: string;
+    a: TrackSeed | null;
+    b: TrackSeed | null;
+    winnerId?: string;
+};
+
+export function buildInitialRound(seeds: TrackSeed[]): Matchup[] {
+    const n = seeds.length;
+    const matchups: Matchup[] = [];
+    for (let i = 0; i < Math.floor(n / 2); i++) {
+        const top = seeds[i];
+        const bottom = seeds[n - 1 - i];
+        matchups.push({ id: `r${n}-${i}`, a: top, b: bottom });
+    }
+    return matchups;
+}
+
+export function advanceRound(prevRound: Matchup[]): Matchup[] {
+    const winners: (TrackSeed | null)[] = [];
+    for (const m of prevRound) {
+        const winner = m.winnerId === m.a?.id ? m.a : m.winnerId === m.b?.id ? m.b : null;
+        winners.push(winner);
+    }
+    const next: Matchup[] = [];
+    for (let i = 0; i < winners.length; i += 2) {
+        next.push({ id: `${prevRound[0]?.id}-n${i / 2}`, a: winners[i] || null, b: winners[i + 1] || null });
+    }
+    return next;
+}
+
+export function computeRoundNames(size: number): string[] {
+    const names: string[] = [];
+    const labels: Record<number, string> = {
+        64: 'Round of 64',
+        32: 'Round of 32',
+        16: 'Sweet 16',
+        8: 'Elite 8',
+        4: 'Final 4',
+        2: 'Championship',
+    };
+    let n = size;
+    while (n >= 2) {
+        names.push(labels[n] || `Round of ${n}`);
+        n = n / 2;
+    }
+    return names;
+}
+
+// Efficiently propagate a change from a specific matchup forward through subsequent rounds.
+// Only updates the affected path (pair index chain) instead of recomputing entire bracket.
+export function propagateWinnerChange(
+    rounds: Matchup[][],
+    roundIndex: number,
+    matchupIndex: number
+): Matchup[][] {
+    const nextRounds = rounds.map((r) => r.map((m) => ({ ...m })));
+
+    for (let r = roundIndex; r < nextRounds.length - 1; r++) {
+        const currentRound = nextRounds[r];
+        const nextRound = nextRounds[r + 1];
+        const pairIndex = Math.floor(matchupIndex / 2);
+        const isFirst = matchupIndex % 2 === 0;
+        const currentMatch = currentRound[matchupIndex];
+        const winner = currentMatch.winnerId === currentMatch.a?.id ? currentMatch.a : currentMatch.winnerId === currentMatch.b?.id ? currentMatch.b : null;
+
+        if (!nextRound) break;
+
+        if (isFirst) {
+            nextRound[pairIndex].a = winner || null;
+        } else {
+            nextRound[pairIndex].b = winner || null;
+        }
+
+        // If downstream node had a winner that no longer matches either side, clear it
+        const downstream = nextRound[pairIndex];
+        if (downstream.winnerId && downstream.winnerId !== downstream.a?.id && downstream.winnerId !== downstream.b?.id) {
+            downstream.winnerId = undefined;
+        }
+
+        // Continue path to next rounds
+        matchupIndex = pairIndex;
+    }
+
+    return nextRounds;
+}
+
+export function pickFinalFour(rounds: Matchup[][]): TrackSeed[] {
+    if (!rounds || rounds.length < 2) return [];
+    const semifinalRound = rounds[rounds.length - 2] || [];
+    const participants: TrackSeed[] = [];
+    for (const m of semifinalRound) {
+        if (m.a) participants.push(m.a);
+        if (m.b) participants.push(m.b);
+    }
+    return participants.slice(0, 4);
+}
+
+export function getChampion(rounds: Matchup[][]): TrackSeed | null {
+    const last = rounds[rounds.length - 1]?.[0];
+    if (!last) return null;
+    return last.winnerId === last.a?.id ? last.a || null : last.b || null;
+}
+

--- a/lib/bracket.ts
+++ b/lib/bracket.ts
@@ -176,7 +176,8 @@ export function pickFinalFour(rounds: Matchup[][]): TrackSeed[] {
 
 export function getChampion(rounds: Matchup[][]): TrackSeed | null {
     const last = rounds[rounds.length - 1]?.[0];
-    if (!last) return null;
-    return last.winnerId === last.a?.id ? last.a || null : last.b || null;
+    if (!last || !last.winnerId) return null;
+    return last.winnerId === last.a?.id ? last.a || null :
+        last.winnerId === last.b?.id ? last.b || null : null;
 }
 

--- a/lib/bracket.ts
+++ b/lib/bracket.ts
@@ -18,11 +18,79 @@ export type Matchup = {
 export function buildInitialRound(seeds: TrackSeed[]): Matchup[] {
     const n = seeds.length;
     const matchups: Matchup[] = [];
-    for (let i = 0; i < Math.floor(n / 2); i++) {
-        const top = seeds[i];
-        const bottom = seeds[n - 1 - i];
-        matchups.push({ id: `r${n}-${i}`, a: top, b: bottom });
+
+    // For 64-team bracket, use proper March Madness seeding
+    if (n === 64) {
+        const regions = [
+            [1, 16, 8, 9, 5, 12, 4, 13, 6, 11, 3, 14, 7, 10, 2, 15], // Region 1
+            [1, 16, 8, 9, 5, 12, 4, 13, 6, 11, 3, 14, 7, 10, 2, 15], // Region 2  
+            [1, 16, 8, 9, 5, 12, 4, 13, 6, 11, 3, 14, 7, 10, 2, 15], // Region 3
+            [1, 16, 8, 9, 5, 12, 4, 13, 6, 11, 3, 14, 7, 10, 2, 15]  // Region 4
+        ];
+
+        let matchupIndex = 0;
+        for (let region = 0; region < 4; region++) {
+            const regionSeeds = regions[region];
+            for (let i = 0; i < regionSeeds.length; i += 2) {
+                const seed1 = regionSeeds[i] + (region * 16); // Offset by region
+                const seed2 = regionSeeds[i + 1] + (region * 16);
+                const team1 = seeds[seed1 - 1]; // Convert to 0-based index
+                const team2 = seeds[seed2 - 1];
+                matchups.push({ id: `r${n}-${matchupIndex}`, a: team1, b: team2 });
+                matchupIndex++;
+            }
+        }
     }
+    // For 32-team bracket
+    else if (n === 32) {
+        const regions = [
+            [1, 16, 8, 9, 5, 12, 4, 13, 6, 11, 3, 14, 7, 10, 2, 15], // Region 1 (seeds 1-16)
+            [1, 16, 8, 9, 5, 12, 4, 13, 6, 11, 3, 14, 7, 10, 2, 15]  // Region 2 (seeds 17-32)
+        ];
+
+        let matchupIndex = 0;
+        for (let region = 0; region < 2; region++) {
+            const regionSeeds = regions[region];
+            for (let i = 0; i < regionSeeds.length; i += 2) {
+                const seed1 = regionSeeds[i] + (region * 16);
+                const seed2 = regionSeeds[i + 1] + (region * 16);
+                const team1 = seeds[seed1 - 1];
+                const team2 = seeds[seed2 - 1];
+                matchups.push({ id: `r${n}-${matchupIndex}`, a: team1, b: team2 });
+                matchupIndex++;
+            }
+        }
+    }
+    // For 16-team bracket
+    else if (n === 16) {
+        const regionSeeds = [1, 16, 8, 9, 5, 12, 4, 13, 6, 11, 3, 14, 7, 10, 2, 15];
+        for (let i = 0; i < regionSeeds.length; i += 2) {
+            const seed1 = regionSeeds[i];
+            const seed2 = regionSeeds[i + 1];
+            const team1 = seeds[seed1 - 1];
+            const team2 = seeds[seed2 - 1];
+            matchups.push({ id: `r${n}-${i / 2}`, a: team1, b: team2 });
+        }
+    }
+    // For 8-team bracket, use simple 1v8, 4v5, 3v6, 2v7 pattern
+    else if (n === 8) {
+        const pairings = [[1, 8], [4, 5], [3, 6], [2, 7]];
+        for (let i = 0; i < pairings.length; i++) {
+            const [seed1, seed2] = pairings[i];
+            const team1 = seeds[seed1 - 1];
+            const team2 = seeds[seed2 - 1];
+            matchups.push({ id: `r${n}-${i}`, a: team1, b: team2 });
+        }
+    }
+    // Fallback to original logic for other sizes
+    else {
+        for (let i = 0; i < Math.floor(n / 2); i++) {
+            const top = seeds[i];
+            const bottom = seeds[n - 1 - i];
+            matchups.push({ id: `r${n}-${i}`, a: top, b: bottom });
+        }
+    }
+
     return matchups;
 }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,15 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "i.scdn.co",
+        pathname: "/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Add a new screen for users to create a March Madness-style bracket from an artist's top 64 Spotify songs.

---
<a href="https://cursor.com/background-agent?bcId=bc-d36db551-7706-4712-8e6e-ade7fcabbf1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d36db551-7706-4712-8e6e-ade7fcabbf1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

