### PR TITLE
Fix memento image preview rendering

### DIFF
--- a/app/(ui)/memento/TemplatePicker.tsx
+++ b/app/(ui)/memento/TemplatePicker.tsx
@@ -46,7 +46,7 @@ export default function TemplatePicker({ templateId, subtitleVariant, previewBas
                 try {
                     const base: Omit<RenderPayload, 'templateId'> = previewBase ?? { partyName: 'Preview', subtitleVariant, date: '', location: '', notes: '', tracks: [], photo: {}, preview: true };
                     const pairs = await Promise.all(templates.map(async (t) => {
-                        const res = await fetch('/api/memento/preview', { method: 'POST', cache: 'no-store', signal: controller.signal, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ...base, subtitleVariant, templateId: t.id }) });
+                        const res = await fetch('/api/memento/preview', { method: 'POST', cache: 'no-store', signal: controller.signal, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ...base, templateId: t.id }) });
                         if (!res.ok) return [t.id, null] as const;
                         const blob = await res.blob();
                         return [t.id, URL.createObjectURL(blob)] as const;

--- a/app/(ui)/memento/TemplatePicker.tsx
+++ b/app/(ui)/memento/TemplatePicker.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { TemplateId, SubtitleVariant, RenderPayload } from "./types";
 
 type Props = {
     templateId: TemplateId;
     subtitleVariant: SubtitleVariant;
+    // Optional: provide current data to render more accurate low-res previews
+    previewBase?: Omit<RenderPayload, 'templateId'>;
     onChange: (t: { templateId: TemplateId; subtitleVariant: SubtitleVariant }) => void;
 };
 
@@ -15,30 +17,47 @@ const templates: Array<{ id: TemplateId; name: string }> = [
     { id: 'square', name: 'Square' },
 ];
 
-export default function TemplatePicker({ templateId, subtitleVariant, onChange }: Props) {
+export default function TemplatePicker({ templateId, subtitleVariant, previewBase, onChange }: Props) {
     const [thumbs, setThumbs] = useState<Record<TemplateId, string | null>>({ portrait: null, landscape: null, square: null });
     const abortRef = useRef<AbortController | null>(null);
+
+    // Build a stable signature for when to refresh thumbnails
+    const previewSig = useMemo(() => {
+        const base = previewBase ?? { partyName: 'Preview', subtitleVariant, date: '', location: '', notes: '', tracks: [], photo: {}, preview: true, showLogo: false };
+        return JSON.stringify({
+            partyName: base.partyName,
+            subtitleVariant,
+            date: base.date ?? '',
+            location: base.location ?? '',
+            notes: base.notes ?? '',
+            showLogo: base.showLogo ?? false,
+            photo: base.photo?.dataUrl ?? base.photo?.url ?? '',
+            tracks: (base.tracks ?? []).slice(0, 20).map((t) => `${t.artist}|${t.title}|${t.mix ?? ''}`),
+        });
+    }, [previewBase, subtitleVariant]);
 
     useEffect(() => {
         const controller = new AbortController();
         abortRef.current?.abort();
         abortRef.current = controller;
-        (async () => {
-            try {
-                const base: Omit<RenderPayload, 'templateId'> = { partyName: 'Preview', subtitleVariant, date: '', location: '', notes: '', tracks: [], photo: {}, preview: true };
-                const pairs = await Promise.all(templates.map(async (t) => {
-                    const res = await fetch('/api/memento/preview', { method: 'POST', signal: controller.signal, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ...base, templateId: t.id }) });
-                    if (!res.ok) return [t.id, null] as const;
-                    const blob = await res.blob();
-                    return [t.id, URL.createObjectURL(blob)] as const;
-                }));
-                const next: Record<TemplateId, string | null> = { portrait: null, landscape: null, square: null };
-                for (const [id, url] of pairs) next[id] = url;
-                setThumbs(next);
-            } catch { /* ignore */ }
-        })();
-        return () => controller.abort();
-    }, [subtitleVariant]);
+        const timeout = setTimeout(() => {
+            (async () => {
+                try {
+                    const base: Omit<RenderPayload, 'templateId'> = previewBase ?? { partyName: 'Preview', subtitleVariant, date: '', location: '', notes: '', tracks: [], photo: {}, preview: true };
+                    const pairs = await Promise.all(templates.map(async (t) => {
+                        const res = await fetch('/api/memento/preview', { method: 'POST', signal: controller.signal, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ...base, subtitleVariant, templateId: t.id }) });
+                        if (!res.ok) return [t.id, null] as const;
+                        const blob = await res.blob();
+                        return [t.id, URL.createObjectURL(blob)] as const;
+                    }));
+                    const next: Record<TemplateId, string | null> = { portrait: null, landscape: null, square: null };
+                    for (const [id, url] of pairs) next[id] = url;
+                    setThumbs(next);
+                } catch { /* ignore */ }
+            })();
+        }, 300);
+        return () => { clearTimeout(timeout); controller.abort(); };
+    }, [subtitleVariant, previewSig, previewBase]);
 
     return (
         <div className="grid grid-cols-3 gap-3">

--- a/app/(ui)/memento/page.tsx
+++ b/app/(ui)/memento/page.tsx
@@ -72,6 +72,18 @@ export default function MementoPage() {
                         <TemplatePicker
                             templateId={state.templateId}
                             subtitleVariant={state.subtitleVariant}
+                            previewBase={{
+                                partyName: state.partyName || 'Preview',
+                                subtitleVariant: state.subtitleVariant,
+                                date: state.date,
+                                location: state.location,
+                                notes: state.notes,
+                                // Only include tracks marked included
+                                tracks: state.tracks.filter((t) => t.included).map(({ artist, title, mix }) => ({ artist, title, mix })),
+                                photo: { dataUrl: photoDataUrl },
+                                preview: true,
+                                showLogo: state.showLogo,
+                            }}
                             onChange={(t) => setState((s) => ({ ...s, ...t }))}
                         />
                         <label className="mt-3 inline-flex items-center gap-2 text-sm">

--- a/app/api/memento/preview/route.ts
+++ b/app/api/memento/preview/route.ts
@@ -11,7 +11,8 @@ export async function POST(req: NextRequest) {
             console.log('[memento/preview] photo dataUrl length', body.photo.dataUrl.length);
         }
         const buf = await composeMemento({ ...body, preview: true });
-        return new Response(buf, { headers: { 'Content-Type': 'image/png', 'Cache-Control': 'no-store' } });
+        const u8 = new Uint8Array(buf);
+        return new Response(u8, { headers: { 'Content-Type': 'image/png', 'Cache-Control': 'no-store' } });
     } catch (err) {
         console.error('[memento/preview] error', err);
         return new Response(JSON.stringify({ error: (err as Error).message }), { status: 500, headers: { 'Content-Type': 'application/json' } });

--- a/app/api/memento/preview/route.ts
+++ b/app/api/memento/preview/route.ts
@@ -11,9 +11,7 @@ export async function POST(req: NextRequest) {
             console.log('[memento/preview] photo dataUrl length', body.photo.dataUrl.length);
         }
         const buf = await composeMemento({ ...body, preview: true });
-        const u8 = new Uint8Array(buf);
-        const blob = new Blob([u8], { type: 'image/png' });
-        return new Response(blob, { headers: { 'Content-Type': 'image/png' } });
+        return new Response(buf, { headers: { 'Content-Type': 'image/png', 'Cache-Control': 'no-store' } });
     } catch (err) {
         console.error('[memento/preview] error', err);
         return new Response(JSON.stringify({ error: (err as Error).message }), { status: 500, headers: { 'Content-Type': 'application/json' } });


### PR DESCRIPTION
Implement reactive low-resolution previews for memento templates to show current data as it's edited.

---
<a href="https://cursor.com/background-agent?bcId=bc-1627dcce-8b20-4609-a958-b3795ab17736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1627dcce-8b20-4609-a958-b3795ab17736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

